### PR TITLE
Add PostgreSQL pgvector retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A FastAPI-based Retrieval-Augmented Generation (RAG) system for Korean legal doc
 
 ## Features
 
-- **Dual Retrieval Methods**: TF-IDF and sentence embedding-based retrieval
+ - **Dual Retrieval Methods**: TF-IDF and sentence embedding-based retrieval
+ - **PostgreSQL Vector Search**: Uses pgvector 0.8 for scalable similarity search
 - **Korean Legal Documents**: Supports 판결문, 법령, 심결례, 유권해석
 - **RESTful API**: Easy-to-use HTTP endpoints
 - **Real-time Search**: Fast document retrieval and ranking
@@ -22,6 +23,8 @@ source .venv/bin/activate  # Linux/Mac
 # or
 .venv\Scripts\activate     # Windows
 ```
+
+3. Set your PostgreSQL connection in the `DATABASE_URL` environment variable.
 
 ## Usage
 
@@ -49,7 +52,7 @@ Request body:
 ```json
 {
   "query": "계약 해지에 관한 판례를 알려줘",
-  "method": "both",  // "tfidf", "embedding", or "both"
+  "method": "both",  // "tfidf", "embedding", "faiss", "pgvector", or "both"
   "top_k": 5
 }
 ```
@@ -74,7 +77,7 @@ import requests
 # Search query
 response = requests.post("http://localhost:8000/search", json={
     "query": "계약 해지에 관한 판례를 알려줘",
-    "method": "both",
+    "method": "both",  # can also use "pgvector"
     "top_k": 5
 })
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,6 @@ dependencies = [
     "scikit-learn>=1.7.0",
     "sentence-transformers>=5.0.0",
     "uvicorn[standard]>=0.24.0",
+    "psycopg[binary]>=3.1.0",
+    "pgvector>=0.4.0",
 ]


### PR DESCRIPTION
## Summary
- support PostgreSQL vector search using pgvector 0.8
- add psycopg and pgvector dependencies
- mention pgvector search and DATABASE_URL in docs

## Testing
- `pip install psycopg[binary] pgvector`
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e64b983c832198f116de0a762307

## Summary by Sourcery

Introduce PostgreSQL vector search capabilities using pgvector for scalable similarity retrieval.

New Features:
- Initialize PostgreSQL with pgvector extension and load sentence embeddings into a vector-enabled table
- Implement context retrieval via SQL vector similarity using pgvector’s <-> operator
- Extend the API to accept “pgvector” as a retrieval method and include pgvector_results in responses

Enhancements:
- Add psycopg[binary] and pgvector dependencies

Documentation:
- Update README to document PostgreSQL vector search setup, DATABASE_URL config, and method options including pgvector