### PR TITLE
feat: automatically load .env configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,11 @@ from pathlib import Path
 from typing import Iterable, Iterator, List, Optional, Tuple
 from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 
+from packages.env import load_env
+
+# Ensure `.env` files are processed before reading configuration defaults.
+load_env()
+
 # Data directories
 DATA_DIR = Path("data")
 

--- a/packages/__init__.py
+++ b/packages/__init__.py
@@ -1,2 +1,8 @@
 """Top-level package namespace for shared libraries."""
 
+from .env import load_env
+
+load_env()
+
+__all__ = ["load_env"]
+

--- a/packages/env.py
+++ b/packages/env.py
@@ -1,0 +1,67 @@
+"""Helpers for loading `.env` files across the project."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Union
+
+from dotenv import find_dotenv, load_dotenv
+
+
+PathLike = Union[str, Path]
+_LOADED = False
+
+
+def load_env(*, override: bool = False, extra_paths: Iterable[PathLike] | None = None) -> bool:
+    """Load environment variables from `.env` files if they exist.
+
+    Args:
+        override: When ``True`` existing variables may be replaced.
+        extra_paths: Optional iterable of additional files to load before the
+            default search locations.
+
+    Returns:
+        ``True`` if any environment file was successfully loaded.
+    """
+
+    global _LOADED
+
+    if _LOADED and not override and extra_paths is None:
+        return True
+
+    loaded_any = False
+    loaded_paths: set[Path] = set()
+
+    if extra_paths is not None:
+        for raw_path in extra_paths:
+            path = Path(raw_path).expanduser()
+            if not path.exists():
+                continue
+            resolved = path.resolve()
+            if resolved in loaded_paths:
+                continue
+            loaded_paths.add(resolved)
+            loaded_any = load_dotenv(resolved, override=override) or loaded_any
+
+    found = find_dotenv(usecwd=True)
+    if found:
+        resolved = Path(found).resolve()
+        if resolved not in loaded_paths and resolved.exists():
+            loaded_paths.add(resolved)
+            loaded_any = load_dotenv(resolved, override=override) or loaded_any
+
+    repo_dotenv = Path(__file__).resolve().parent.parent / ".env"
+    if repo_dotenv.exists():
+        resolved = repo_dotenv.resolve()
+        if resolved not in loaded_paths:
+            loaded_paths.add(resolved)
+            loaded_any = load_dotenv(resolved, override=override) or loaded_any
+
+    if not override:
+        _LOADED = True
+
+    return loaded_any
+
+
+load_env()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "langchain-openai>=0.1.8",
     "langchain-google-genai>=0.0.7",
     "langgraph>=0.6.0,<0.7",
+    "python-dotenv>=1.0",
 ]
 
 [project.scripts]

--- a/scripts/pg_load_jsonl.py
+++ b/scripts/pg_load_jsonl.py
@@ -5,6 +5,10 @@ import os
 from pathlib import Path
 from typing import Iterable, Iterator, Tuple
 
+from packages.env import load_env
+
+load_env()
+
 
 def ensure_psycopg():
     try:

--- a/scripts/supabase_load.py
+++ b/scripts/supabase_load.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 from typing import Iterable
 
+from packages.env import load_env
+
+load_env()
+
 
 def iter_json_files(root: Path) -> Iterable[Path]:
     for p in root.rglob("*.json"):

--- a/uv.lock
+++ b/uv.lock
@@ -45,12 +45,22 @@ source = { virtual = "." }
 dependencies = [
     { name = "duckdb" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "python-dotenv" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "duckdb", specifier = ">=0.9.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add python-dotenv to the project and provide a shared helper to load .env files
- invoke the helper from the CLI entrypoint and data ingestion scripts so configuration is available automatically
- expose the loader from the packages namespace for reuse in other modules

## Testing
- pytest -q *(fails: SyntaxError: invalid syntax in tests/test_law_go_kr.py line 362 because the file ends with the literal `*** End of File`)*

------
https://chatgpt.com/codex/tasks/task_e_68c926eaf0c48321b7e3abfe1a85da90

## Summary by Sourcery

Introduce automatic loading of .env configuration across the project to streamline environment management

New Features:
- Add `packages/env.py` with a `load_env` helper using python-dotenv
- Invoke `load_env()` in the main entrypoint and data ingestion scripts to auto-load .env files
- Re-export `load_env` in the top-level package namespace for reuse

Build:
- Add `python-dotenv` dependency in pyproject.toml