### PR TITLE
Add debug logging for law.go.kr API calls

### DIFF
--- a/tests/test_law_go_kr.py
+++ b/tests/test_law_go_kr.py
@@ -359,4 +359,3 @@ def test_tool_law_go_interpretation_detail_returns_hit(monkeypatch: pytest.Monke
     assert len(hits) == 1
     assert hits[0].source == "law_api"
     assert "해석기관" in hits[0].snippet
-*** End of File


### PR DESCRIPTION
## Summary
- add debug-level logging around law.go.kr API requests and responses to aid troubleshooting
- redact OC credentials and clip response previews to avoid leaking sensitive data in logs

## Testing
- ruff check packages/legal_tools/law_go_kr.py
- pytest -q *(fails: SyntaxError: invalid syntax in tests/test_law_go_kr.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c94dea81a88321a802c3dae1e79b4b

## Summary by Sourcery

Add debug-level logging to law.go.kr API calls, including request URLs, response metadata, and body parsing events, while redacting sensitive OC credentials and clipping response previews for safe logging.

Enhancements:
- Introduce debug logging for request URLs and parameters, response metadata, and parsing events
- Add helper functions to redact OC credentials and mask secrets
- Add helper function to clip long response bodies for log previews