### PR TITLE
refactor: remove DuckDB and ChromaDB remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Notes:
 
 Supabase/Postgres (optional; BM25 FTS)
 -------------------------------------
-Enable PostgreSQL-backed full-text search using ParadeDB BM25. This is optional; DuckDB remains default.
+Enable PostgreSQL-backed full-text search using ParadeDB BM25. This is optional; Meilisearch remains default.
 
 1) Install optional dependency:
 ```


### PR DESCRIPTION
## Summary
- delete the unused DuckDB search implementation and related CLI stubs
- clean up the parser comments to reflect the remaining commands
- update README to note Meilisearch as the default search backend

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d638267d148321a39895c547a310d4

## Summary by Sourcery

Remove all remnants of the DuckDB-based search and ChromaDB RAG commands, clean up CLI parser comments accordingly, and update documentation to set Meilisearch as the default search backend

Enhancements:
- Remove the entire DuckDB search implementation and related CLI stubs
- Eliminate RAG MVP commands referencing DuckDB and ChromaDB embeddings
- Streamline argument parser comments to reflect remaining commands

Documentation:
- Update README to designate Meilisearch instead of DuckDB as the default search backend