### PR TITLE
feat: persist chat threads in API server with Postgres checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Notes:
 
 ### Postgres-backed multi-turn chat
 
-Set `LAW_CHAT_DB_URL` (or `DATABASE_URL`/`PG_DSN`) to enable the LangGraph `PostgresSaver` checkpoint store. The server will lazily
+Set `LAW_CHAT_DB_URL` (defaults to `SUPABASE_DB_URL`, `DATABASE_URL`, or `PG_DSN` when unset) to enable the LangGraph `PostgresSaver` checkpoint store. The server will lazily
 initialize a persistent chat graph, run `.setup()` on first use, and emit `X-Thread-ID` / `X-Checkpoint-ID` headers so callers can
 resume conversations.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,39 @@ Notes:
 - Set `LAW_DATA_DIR` to point to your data folder if not `./data`.
 - The server runs the same LangGraph agent as the CLI and streams the final answer in chunks.
 
+### Postgres-backed multi-turn chat
+
+Set `LAW_CHAT_DB_URL` (or `DATABASE_URL`/`PG_DSN`) to enable the LangGraph `PostgresSaver` checkpoint store. The server will lazily
+initialize a persistent chat graph, run `.setup()` on first use, and emit `X-Thread-ID` / `X-Checkpoint-ID` headers so callers can
+resume conversations.
+
+```
+export LAW_CHAT_DB_URL="postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
+export OPENAI_API_KEY=...
+
+# first call creates a new thread (thread id returned in headers / body)
+curl -i http://127.0.0.1:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "openai:gpt-4o-mini",
+    "messages": [{"role":"user","content":"안녕! 넌 누구야?"}]
+  }'
+
+# reuse the thread for the follow-up turn
+curl -i http://127.0.0.1:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "thread_id": "thread-abc123",  # use the id from the previous response/header
+    "messages": [{"role":"user","content":"내가 방금 뭐라고 했지?"}]
+  }'
+
+# inspect checkpoints (latest first)
+curl -s http://127.0.0.1:8080/threads/thread-abc123/history | jq
+```
+
+Each turn is saved as a checkpoint keyed by `thread_id`, enabling replay, branching, or offline inspection via the HTTP history
+endpoint.
+
 Supabase/Postgres (optional; BM25 FTS)
 -------------------------------------
 Enable PostgreSQL-backed full-text search using ParadeDB BM25. This is optional; OpenSearch remains default.

--- a/packages/legal_tools/__init__.py
+++ b/packages/legal_tools/__init__.py
@@ -6,6 +6,23 @@ features (like the LangGraph agent) usable without extra installs.
 
 __all__ = []
 
+try:  # pragma: no cover - optional dependency (LangGraph + Postgres)
+    from .multi_turn_chat import (  # type: ignore
+        ChatResponse,
+        PostgresChatConfig,
+        PostgresChatManager,
+    )
+
+    __all__.extend(
+        [
+            "ChatResponse",
+            "PostgresChatConfig",
+            "PostgresChatManager",
+        ]
+    )
+except Exception:
+    pass
+
 # Expose contextual_rag symbols lazily if dependencies are available
 try:  # pragma: no cover - optional import
     from .contextual_rag import (  # type: ignore
@@ -15,12 +32,14 @@ try:  # pragma: no cover - optional import
         IndexRecord,
     )
 
-    __all__.extend([
-        "ContextConfig",
-        "ContextualChunker",
-        "EmbeddingModel",
-        "IndexRecord",
-    ])
+    __all__.extend(
+        [
+            "ContextConfig",
+            "ContextualChunker",
+            "EmbeddingModel",
+            "IndexRecord",
+        ]
+    )
 except Exception:
     # Optional module not available (e.g., missing pydantic).
     # This keeps `packages.legal_tools` importable for other features like pg_search/agent_graph.

--- a/packages/legal_tools/api_server.py
+++ b/packages/legal_tools/api_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 import uuid
@@ -8,8 +9,28 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from packages.legal_tools.agent_graph import run_ask
+
+try:  # Optional dependency guard for multi-turn chat support
+    from packages.legal_tools.multi_turn_chat import (
+        ChatResponse,
+        PostgresChatConfig,
+        PostgresChatManager,
+    )
+except Exception:  # pragma: no cover - keep server usable without LangGraph deps
+    PostgresChatConfig = None  # type: ignore[assignment]
+    PostgresChatManager = None  # type: ignore[assignment]
+    ChatResponse = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+_CHAT_MANAGER: Optional[PostgresChatManager] = None
+_CHAT_MANAGER_ERROR: Optional[str] = None
 
 
 def _extract_question(messages: List[Dict[str, Any]]) -> str:
@@ -27,6 +48,35 @@ def _json_response(obj: Dict[str, Any]) -> bytes:
     return json.dumps(obj, ensure_ascii=False).encode("utf-8")
 
 
+def _get_chat_manager() -> Optional[PostgresChatManager]:
+    """Lazily initialize the Postgres-backed chat manager."""
+
+    global _CHAT_MANAGER, _CHAT_MANAGER_ERROR
+    if PostgresChatManager is None:
+        if not _CHAT_MANAGER_ERROR:
+            _CHAT_MANAGER_ERROR = "multi-turn chat dependencies unavailable"
+            logger.debug("chat_manager_unavailable", reason=_CHAT_MANAGER_ERROR)
+        return None
+    if _CHAT_MANAGER is not None:
+        return _CHAT_MANAGER
+    if _CHAT_MANAGER_ERROR:
+        return None
+    try:
+        config = PostgresChatConfig.from_env()
+    except Exception as exc:  # pragma: no cover - env-specific config
+        _CHAT_MANAGER_ERROR = str(exc)
+        logger.debug("chat_manager_config_missing", error=_CHAT_MANAGER_ERROR)
+        return None
+    try:
+        _CHAT_MANAGER = PostgresChatManager(config=config)
+    except Exception as exc:  # pragma: no cover - runtime DB connectivity
+        _CHAT_MANAGER_ERROR = str(exc)
+        logger.error("chat_manager_init_failed", error=_CHAT_MANAGER_ERROR)
+        return None
+    logger.info("chat_manager_ready")
+    return _CHAT_MANAGER
+
+
 class ChatHandler(BaseHTTPRequestHandler):
     server_version = "LawAPI/0.1"
 
@@ -34,6 +84,14 @@ class ChatHandler(BaseHTTPRequestHandler):
         # Reduce noise; honor LOG_REQUESTS=1 to enable
         if os.getenv("LOG_REQUESTS"):
             super().log_message(format, *args)
+
+    def do_GET(self) -> None:  # noqa: N802 - http.server API
+        parsed = urlparse(self.path)
+        parts = [segment for segment in parsed.path.split("/") if segment]
+        if len(parts) == 3 and parts[0] == "threads" and parts[2] == "history":
+            self._handle_thread_history(parts[1])
+            return
+        self.send_error(HTTPStatus.NOT_FOUND, "Unknown endpoint")
 
     def do_POST(self) -> None:  # noqa: N802 - http.server API
         if self.path.rstrip("/") == "/v1/chat/completions":
@@ -64,16 +122,51 @@ class ChatHandler(BaseHTTPRequestHandler):
         # Resolve data directory
         data_dir = Path(os.getenv("LAW_DATA_DIR") or "data")
 
+        thread_id = str(req.get("thread_id") or "").strip()
+        chat_result: Optional[ChatResponse] = None
+        checkpoint_id: Optional[str] = None
+        manager = _get_chat_manager() if messages else None
+        if manager is not None and messages:
+            if not thread_id:
+                thread_id = manager.new_thread_id()
+            try:
+                chat_result = manager.send_messages(
+                    thread_id=thread_id, messages=messages
+                )
+                checkpoint_id = chat_result.checkpoint_id
+            except ValueError as exc:
+                self.send_error(HTTPStatus.BAD_REQUEST, str(exc))
+                return
+            except Exception as exc:  # pragma: no cover - runtime DB/model state
+                logger.exception("chat_manager_invoke_failed", exc_info=exc)
+                chat_result = None
+
         question = _extract_question(messages)
         created = int(time.time())
         chat_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
 
-        # Run the agent (blocking). We stream the resulting answer in chunks if requested.
-        result = run_ask(question, data_dir=data_dir, top_k=top_k, max_iters=max_iters)
-        answer: str = (result.get("answer") or "").strip()
+        if chat_result is None or not chat_result.last_text():
+            # Run the single-turn agent as a fallback or when multi-turn is disabled.
+            result = run_ask(
+                question, data_dir=data_dir, top_k=top_k, max_iters=max_iters
+            )
+            answer: str = (result.get("answer") or "").strip()
+        else:
+            answer = chat_result.last_text()
+            checkpoint_id = checkpoint_id or chat_result.checkpoint_id
+
+        if chat_result is not None:
+            thread_id = chat_result.thread_id
 
         if stream:
-            self._stream_answer(chat_id, model, created, answer)
+            self._stream_answer(
+                chat_id,
+                model,
+                created,
+                answer,
+                thread_id=thread_id or None,
+                checkpoint_id=checkpoint_id,
+            )
             return
 
         # Non-streaming response
@@ -89,21 +182,46 @@ class ChatHandler(BaseHTTPRequestHandler):
                     "finish_reason": "stop",
                 }
             ],
-            "usage": {"prompt_tokens": 0, "completion_tokens": len(answer), "total_tokens": len(answer)},
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": len(answer),
+                "total_tokens": len(answer),
+            },
         }
+        if thread_id:
+            resp["thread_id"] = thread_id
+        if checkpoint_id:
+            resp.setdefault("law", {})["checkpoint_id"] = checkpoint_id
         body = _json_response(resp)
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", "application/json; charset=utf-8")
+        if thread_id:
+            self.send_header("X-Thread-ID", thread_id)
+        if checkpoint_id:
+            self.send_header("X-Checkpoint-ID", checkpoint_id)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
-    def _stream_answer(self, chat_id: str, model: str, created: int, answer: str) -> None:
+    def _stream_answer(
+        self,
+        chat_id: str,
+        model: str,
+        created: int,
+        answer: str,
+        *,
+        thread_id: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
+    ) -> None:
         # Prepare headers for SSE-compatible streaming
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", "text/event-stream; charset=utf-8")
         self.send_header("Cache-Control", "no-cache")
         self.send_header("Connection", "keep-alive")
+        if thread_id:
+            self.send_header("X-Thread-ID", thread_id)
+        if checkpoint_id:
+            self.send_header("X-Checkpoint-ID", checkpoint_id)
         self.end_headers()
 
         # First chunk with role
@@ -112,7 +230,9 @@ class ChatHandler(BaseHTTPRequestHandler):
             "object": "chat.completion.chunk",
             "created": created,
             "model": model,
-            "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+            "choices": [
+                {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+            ],
         }
         self._sse_send(first)
 
@@ -150,6 +270,26 @@ class ChatHandler(BaseHTTPRequestHandler):
             self.wfile.flush()
         except Exception:
             pass
+
+    def _handle_thread_history(self, thread_id: str) -> None:
+        manager = _get_chat_manager()
+        if manager is None:
+            self.send_error(
+                HTTPStatus.SERVICE_UNAVAILABLE, "Multi-turn chat is not configured"
+            )
+            return
+        try:
+            history = manager.get_history(thread_id)
+        except ValueError as exc:
+            self.send_error(HTTPStatus.BAD_REQUEST, str(exc))
+            return
+        payload = {"thread_id": thread_id, "history": history}
+        body = _json_response(payload)
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
     def _sse_send(self, obj: Dict[str, Any]) -> None:
         data = json.dumps(obj, ensure_ascii=False)

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -218,10 +218,14 @@ class PostgresChatManager:
     def _last_assistant(
         self, messages: Iterable[Dict[str, Any]]
     ) -> Optional[Dict[str, Any]]:
-        for msg in reversed(list(messages)):
-            if self._normalize_role(msg.get("role")) == "assistant":
-                return msg
-        return None
+        return next(
+            (
+                msg
+                for msg in reversed(list(messages))
+                if self._normalize_role(msg.get("role")) == "assistant"
+            ),
+            None,
+        )
 
     def _normalize_thread_id(self, thread_id: str) -> str:
         tid = str(thread_id or "").strip()

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -230,8 +230,8 @@ class PostgresChatManager:
             raise ValueError("thread_id must be a non-empty string.")
         if len(tid) > 200:
             raise ValueError("thread_id is too long (max 200 characters).")
-        if any(ch.isspace() for ch in tid):
-            raise ValueError("thread_id cannot contain whitespace characters.")
+        if ' ' in tid:
+            raise ValueError("thread_id cannot contain space characters.")
         return tid
 
     def _normalize_role(self, role: Optional[str]) -> str:

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -255,13 +255,14 @@ class PostgresChatManager:
         if isinstance(content, list):
             parts: List[str] = []
             for item in content:
-                if isinstance(item, dict):
-                    if "text" in item:
-                        parts.append(str(item["text"]))
-                    elif item.get("type") == "text":
-                        parts.append(str(item.get("text", "")))
-                    else:
-                        parts.append(str(item))
+                if isinstance(item, dict) and "text" in item:
+                    parts.append(str(item["text"]))
+                elif (
+                    isinstance(item, dict)
+                    and "text" not in item
+                    and item.get("type") == "text"
+                ):
+                    parts.append(str(item.get("text", "")))
                 else:
                     parts.append(str(item))
             return "".join(parts)

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -27,6 +27,7 @@ class PostgresChatConfig:
 
         db_uri = (
             os.getenv("LAW_CHAT_DB_URL")
+            or os.getenv("SUPABASE_DB_URL")
             or os.getenv("DATABASE_URL")
             or os.getenv("PG_DSN")
             or ""

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -55,9 +55,7 @@ class ChatResponse:
         if not self.response:
             return ""
         content = self.response.get("content")
-        if isinstance(content, str):
-            return content
-        return str(content or "")
+        return content if isinstance(content, str) else str(content or "")
 
 
 class PostgresChatManager:

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -176,8 +176,7 @@ class PostgresChatManager:
             role = self._normalize_role(getattr(message, "role", None) or message.type)
             content = self._coerce_content(getattr(message, "content", ""))
             data: Dict[str, Any] = {"role": role, "content": content}
-            extra = getattr(message, "additional_kwargs", None)
-            if extra:
+            if extra := getattr(message, "additional_kwargs", None):
                 data["additional_kwargs"] = dict(extra)
             return data
         if isinstance(message, dict):

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from langchain.chat_models import init_chat_model
+from langchain_core.messages import BaseMessage
+from langgraph.checkpoint.postgres import PostgresSaver
+from langgraph.graph import MessagesState, StateGraph, START, END
+
+__all__ = ["PostgresChatConfig", "ChatResponse", "PostgresChatManager"]
+
+
+@dataclass
+class PostgresChatConfig:
+    """Configuration for the multi-turn chat graph."""
+
+    db_uri: str
+    model_id: str = os.getenv("LAW_CHAT_MODEL", "openai:gpt-4o-mini")
+    auto_setup: bool = True
+
+    @classmethod
+    def from_env(cls) -> "PostgresChatConfig":
+        """Create a configuration from environment variables."""
+
+        db_uri = (
+            os.getenv("LAW_CHAT_DB_URL")
+            or os.getenv("DATABASE_URL")
+            or os.getenv("PG_DSN")
+            or ""
+        )
+        if not db_uri:
+            raise RuntimeError(
+                "Set LAW_CHAT_DB_URL, DATABASE_URL, or PG_DSN to enable Postgres persistence."
+            )
+        model_id = os.getenv("LAW_CHAT_MODEL", "openai:gpt-4o-mini")
+        return cls(db_uri=db_uri, model_id=model_id)
+
+
+@dataclass
+class ChatResponse:
+    """Result of a multi-turn chat invocation."""
+
+    thread_id: str
+    messages: List[Dict[str, Any]]
+    response: Optional[Dict[str, Any]]
+    checkpoint_id: Optional[str]
+    invoked: bool
+
+    def last_text(self) -> str:
+        """Return the assistant text response, if any."""
+
+        if not self.response:
+            return ""
+        content = self.response.get("content")
+        if isinstance(content, str):
+            return content
+        return str(content or "")
+
+
+class PostgresChatManager:
+    """Stateful chat graph backed by a PostgreSQL checkpointer."""
+
+    def __init__(self, *, config: PostgresChatConfig):
+        self.config = config
+        self._model = init_chat_model(config.model_id)
+        self._checkpointer = PostgresSaver.from_conn_string(config.db_uri)
+        if config.auto_setup:
+            self._checkpointer.setup()
+        builder = StateGraph(MessagesState)
+        builder.add_node("chat_model", self._call_model)
+        builder.add_edge(START, "chat_model")
+        builder.add_edge("chat_model", END)
+        self._graph = builder.compile(checkpointer=self._checkpointer)
+
+    # ----------------------------- public API -----------------------------
+    def send_messages(
+        self, *, thread_id: str, messages: Sequence[Dict[str, Any]]
+    ) -> ChatResponse:
+        """Append messages to a thread and return the assistant reply."""
+
+        tid = self._normalize_thread_id(thread_id)
+        cfg = {"configurable": {"thread_id": tid}}
+        incoming = [self._prepare_incoming_message(m) for m in messages if m]
+        if not incoming:
+            raise ValueError("No messages supplied for invocation.")
+        existing, existing_keys, _ = self._load_state(cfg)
+        incoming_keys = [self._compare_key(m) for m in incoming]
+        shared = self._shared_prefix(existing_keys, incoming_keys)
+        new_payloads = incoming[shared:]
+        invoked = bool(new_payloads)
+        if invoked:
+            self._graph.invoke({"messages": new_payloads}, cfg)
+        updated, _, snapshot = self._load_state(cfg)
+        response = self._last_assistant(updated)
+        checkpoint_id = self._extract_checkpoint_id(snapshot)
+        return ChatResponse(
+            thread_id=tid,
+            messages=updated,
+            response=response,
+            checkpoint_id=checkpoint_id,
+            invoked=invoked,
+        )
+
+    def get_messages(self, thread_id: str) -> List[Dict[str, Any]]:
+        """Return the current message state for a thread."""
+
+        cfg = {"configurable": {"thread_id": self._normalize_thread_id(thread_id)}}
+        messages, _, _ = self._load_state(cfg)
+        return messages
+
+    def get_history(self, thread_id: str) -> List[Dict[str, Any]]:
+        """Return the checkpoint history for a thread (latest first)."""
+
+        cfg = {"configurable": {"thread_id": self._normalize_thread_id(thread_id)}}
+        history = []
+        for snap in self._graph.get_state_history(cfg):
+            messages = [
+                self._message_to_dict(m) for m in snap.values.get("messages", [])
+            ]
+            history.append(
+                {
+                    "checkpoint_id": self._extract_checkpoint_id(snap),
+                    "messages": messages,
+                }
+            )
+        return history
+
+    def new_thread_id(self, *, prefix: str = "thread") -> str:
+        """Generate a unique thread identifier."""
+
+        token = uuid.uuid4().hex
+        return f"{prefix}-{token}"
+
+    # --------------------------- internal helpers -------------------------
+    def _call_model(
+        self, state: MessagesState, config: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        response = self._model.invoke(state["messages"])
+        return {"messages": [response]}
+
+    def _load_state(
+        self, cfg: Dict[str, Any]
+    ) -> Tuple[List[Dict[str, Any]], List[Tuple[str, str]], Optional[Any]]:
+        snapshot = self._graph.get_state(cfg)
+        if snapshot is None:
+            return [], [], None
+        raw = snapshot.values.get("messages", [])
+        messages = [self._message_to_dict(msg) for msg in raw]
+        keys = [self._compare_key(msg) for msg in messages]
+        return messages, keys, snapshot
+
+    def _extract_checkpoint_id(self, snapshot: Optional[Any]) -> Optional[str]:
+        if snapshot is None:
+            return None
+        config = snapshot.config or {}
+        configurable = config.get("configurable") or {}
+        return configurable.get("checkpoint_id")
+
+    def _prepare_incoming_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        role = self._normalize_role(message.get("role") or message.get("type"))
+        content = self._coerce_content(message.get("content"))
+        payload: Dict[str, Any] = {"role": role, "content": content}
+        for key in ("name", "tool_calls", "tool_call_id", "function_call"):
+            if key in message:
+                payload[key] = message[key]
+        if "metadata" in message:
+            payload.setdefault("additional_kwargs", {})
+            payload["additional_kwargs"].update(dict(message["metadata"]))
+        return payload
+
+    def _message_to_dict(self, message: Any) -> Dict[str, Any]:
+        if isinstance(message, BaseMessage):
+            role = self._normalize_role(getattr(message, "role", None) or message.type)
+            content = self._coerce_content(getattr(message, "content", ""))
+            data: Dict[str, Any] = {"role": role, "content": content}
+            extra = getattr(message, "additional_kwargs", None)
+            if extra:
+                data["additional_kwargs"] = dict(extra)
+            return data
+        if isinstance(message, dict):
+            role = self._normalize_role(message.get("role") or message.get("type"))
+            content = self._coerce_content(message.get("content"))
+            data = {"role": role, "content": content}
+            for key in (
+                "additional_kwargs",
+                "metadata",
+                "name",
+                "tool_calls",
+                "tool_call_id",
+            ):
+                if key in message:
+                    data[key] = message[key]
+            return data
+        return {
+            "role": "assistant",
+            "content": self._coerce_content(message),
+        }
+
+    def _compare_key(self, message: Dict[str, Any]) -> Tuple[str, str]:
+        role = self._normalize_role(message.get("role"))
+        content = self._coerce_content(message.get("content"))
+        return role, content.strip()
+
+    def _shared_prefix(
+        self,
+        existing: Sequence[Tuple[str, str]],
+        incoming: Sequence[Tuple[str, str]],
+    ) -> int:
+        count = 0
+        for old, new in zip(existing, incoming):
+            if old != new:
+                break
+            count += 1
+        return count
+
+    def _last_assistant(
+        self, messages: Iterable[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        for msg in reversed(list(messages)):
+            if self._normalize_role(msg.get("role")) == "assistant":
+                return msg
+        return None
+
+    def _normalize_thread_id(self, thread_id: str) -> str:
+        tid = str(thread_id or "").strip()
+        if not tid:
+            raise ValueError("thread_id must be a non-empty string.")
+        if len(tid) > 200:
+            raise ValueError("thread_id is too long (max 200 characters).")
+        if any(ch.isspace() for ch in tid):
+            raise ValueError("thread_id cannot contain whitespace characters.")
+        return tid
+
+    def _normalize_role(self, role: Optional[str]) -> str:
+        value = (role or "").strip().lower()
+        if value in {"ai", "assistant"}:
+            return "assistant"
+        if value in {"human", "user"}:
+            return "user"
+        if value == "system":
+            return "system"
+        if value == "tool":
+            return "tool"
+        return value or "assistant"
+
+    def _coerce_content(self, content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: List[str] = []
+            for item in content:
+                if isinstance(item, dict):
+                    if "text" in item:
+                        parts.append(str(item["text"]))
+                    elif item.get("type") == "text":
+                        parts.append(str(item.get("text", "")))
+                    else:
+                        parts.append(str(item))
+                else:
+                    parts.append(str(item))
+            return "".join(parts)
+        return str(content)

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -245,9 +245,7 @@ class PostgresChatManager:
             return "user"
         if value == "system":
             return "system"
-        if value == "tool":
-            return "tool"
-        return value or "assistant"
+        return "tool" if value == "tool" else value or "assistant"
 
     def _coerce_content(self, content: Any) -> str:
         if content is None:


### PR DESCRIPTION
## Summary
- add a LangGraph PostgresSaver-backed chat manager that stores thread checkpoints
- wire the OpenAI-compatible server to reuse thread state, expose history, and return thread/checkpoint headers
- document how to enable multi-turn persistence via LAW_CHAT_DB_URL

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6ba98a154832190e018f20970b6b0

## Summary by Sourcery

Enable optional multi-turn chat persistence in the API server using a Postgres-backed checkpoint store, enrich chat endpoints with thread state management, and document the new configuration and usage

New Features:
- Add optional Postgres-backed multi-turn chat manager to persist conversation threads and checkpoints
- Enhance /v1/chat/completions endpoint to handle thread IDs, emit X-Thread-ID and X-Checkpoint-ID headers, and fallback to single-turn when multi-turn is unavailable
- Add GET /threads/{thread_id}/history endpoint to retrieve conversation history and checkpoints

Enhancements:
- Lazily initialize multi-turn chat manager based on LAW_CHAT_DB_URL and handle dependency/configuration errors gracefully

Documentation:
- Update README with instructions for enabling and using Postgres-backed multi-turn chat persistence