### PR TITLE
fix: restore missing ai_frontend lib assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ dist/
 downloads/
 eggs/
 .eggs/
+# Python virtual environment libraries
 lib/
 lib64/
 parts/
@@ -102,6 +103,10 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# Allow the Next.js frontend to commit its TypeScript sources under lib/
+!/packages/ai_frontend/lib/
+!/packages/ai_frontend/lib/**
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/packages/ai_frontend/.env.example
+++ b/packages/ai_frontend/.env.example
@@ -4,9 +4,13 @@ AUTH_SECRET=****
 # The following keys below are automatically created and
 # added to your environment when you deploy on vercel
 
-# AI Gateway API Key (required for non-Vercel deployments)
-# For Vercel deployments, OIDC tokens are used automatically
-AI_GATEWAY_API_KEY=****
+# Optional overrides for the OpenAI-compatible gateway (defaults to http://127.0.0.1:8080/v1)
+# OPENAI_COMPATIBLE_BASE_URL=http://127.0.0.1:8080/v1
+# OPENAI_COMPATIBLE_API_KEY=****
+# OPENAI_COMPATIBLE_MODEL=law-gateway
+# OPENAI_COMPATIBLE_REASONING_MODEL=law-gateway
+# OPENAI_COMPATIBLE_TITLE_MODEL=law-gateway
+# OPENAI_COMPATIBLE_ARTIFACT_MODEL=law-gateway
 
 
 # Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob

--- a/packages/ai_frontend/README.md
+++ b/packages/ai_frontend/README.md
@@ -36,15 +36,27 @@
 
 ## Model Providers
 
-This template uses the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) to access multiple AI models through a unified interface. The default configuration includes [xAI](https://x.ai) models (`grok-2-vision-1212`, `grok-3-mini`) routed through the gateway.
+This template targets the local OpenAI-compatible gateway served by `uv run main.py serve --host 127.0.0.1 --port 8080`. By default the frontend sends requests to `http://127.0.0.1:8080/v1`. Override or secure the endpoint with the following environment variables:
 
-### AI Gateway Authentication
+- `OPENAI_COMPATIBLE_BASE_URL` – optional base URL override when the gateway is hosted elsewhere.
+- `OPENAI_COMPATIBLE_API_KEY` – optional bearer token if the gateway enforces authentication.
+- `OPENAI_COMPATIBLE_MODEL` (plus the `*_REASONING`, `*_TITLE`, `*_ARTIFACT` variants) – optional model IDs forwarded in the `model` field.
 
-**For Vercel deployments**: Authentication is handled automatically via OIDC tokens.
+You can still swap in any other provider supported by the [AI SDK](https://ai-sdk.dev/providers/ai-sdk-providers) by editing `lib/ai/providers.ts`.
 
-**For non-Vercel deployments**: You need to provide an AI Gateway API key by setting the `AI_GATEWAY_API_KEY` environment variable in your `.env.local` file.
+### Manual Gateway Check
 
-With the [AI SDK](https://ai-sdk.dev/docs/introduction), you can also switch to direct LLM providers like [OpenAI](https://openai.com), [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://ai-sdk.dev/providers/ai-sdk-providers) with just a few lines of code.
+Once the backend gateway is running you can issue a quick curl to confirm streaming responses:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-5-mini-2025-08-07",
+    "messages": [{"role":"user","content":"근로시간 면제업무 관련 판례 알려줘"}],
+    "stream": true
+  }'
+```
 
 ## Deploy Your Own
 
@@ -67,4 +79,4 @@ pnpm install
 pnpm dev
 ```
 
-Your app template should now be running on [localhost:3000](http://localhost:3000).
+The dev server listens on [http://127.0.0.1:8080](http://127.0.0.1:8080) by default.

--- a/packages/ai_frontend/drizzle.config.ts
+++ b/packages/ai_frontend/drizzle.config.ts
@@ -1,5 +1,6 @@
 import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
+import { getPostgresUrl } from "./lib/db/env";
 
 config({
   path: ".env.local",
@@ -10,7 +11,6 @@ export default defineConfig({
   out: "./lib/db/migrations",
   dialect: "postgresql",
   dbCredentials: {
-    // biome-ignore lint: Forbidden non-null assertion.
-    url: process.env.POSTGRES_URL!,
+    url: getPostgresUrl(),
   },
 });

--- a/packages/ai_frontend/lib/ai/entitlements.ts
+++ b/packages/ai_frontend/lib/ai/entitlements.ts
@@ -1,0 +1,29 @@
+import type { UserType } from "@/app/(auth)/auth";
+import type { ChatModel } from "./models";
+
+type Entitlements = {
+  maxMessagesPerDay: number;
+  availableChatModelIds: ChatModel["id"][];
+};
+
+export const entitlementsByUserType: Record<UserType, Entitlements> = {
+  /*
+   * For users without an account
+   */
+  guest: {
+    maxMessagesPerDay: 20,
+    availableChatModelIds: ["chat-model", "chat-model-reasoning"],
+  },
+
+  /*
+   * For users with an account
+   */
+  regular: {
+    maxMessagesPerDay: 100,
+    availableChatModelIds: ["chat-model", "chat-model-reasoning"],
+  },
+
+  /*
+   * TODO: For users with an account and a paid membership
+   */
+};

--- a/packages/ai_frontend/lib/ai/models.mock.ts
+++ b/packages/ai_frontend/lib/ai/models.mock.ts
@@ -1,0 +1,38 @@
+import type { LanguageModel } from "ai";
+
+const createMockModel = (): LanguageModel => {
+  return {
+    specificationVersion: "v2",
+    provider: "mock",
+    modelId: "mock-model",
+    defaultObjectGenerationMode: "tool",
+    supportedUrls: [],
+    supportsImageUrls: false,
+    supportsStructuredOutputs: false,
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: "text", text: "Hello, world!" }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            type: "text-delta",
+            id: "mock-id",
+            delta: "Mock response",
+          });
+          controller.close();
+        },
+      }),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+    }),
+  } as unknown as LanguageModel;
+};
+
+export const chatModel = createMockModel();
+export const reasoningModel = createMockModel();
+export const titleModel = createMockModel();
+export const artifactModel = createMockModel();

--- a/packages/ai_frontend/lib/ai/models.test.ts
+++ b/packages/ai_frontend/lib/ai/models.test.ts
@@ -1,0 +1,84 @@
+import { simulateReadableStream } from "ai";
+import { MockLanguageModelV2 } from "ai/test";
+import { getResponseChunksByPrompt } from "@/tests/prompts/utils";
+
+export const chatModel = new MockLanguageModelV2({
+  doGenerate: async () => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    finishReason: "stop",
+    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    content: [{ type: "text", text: "Hello, world!" }],
+    warnings: [],
+  }),
+  doStream: async ({ prompt }) => ({
+    stream: simulateReadableStream({
+      chunkDelayInMs: 500,
+      initialDelayInMs: 1000,
+      chunks: getResponseChunksByPrompt(prompt),
+    }),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+  }),
+});
+
+export const reasoningModel = new MockLanguageModelV2({
+  doGenerate: async () => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    finishReason: "stop",
+    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    content: [{ type: "text", text: "Hello, world!" }],
+    warnings: [],
+  }),
+  doStream: async ({ prompt }) => ({
+    stream: simulateReadableStream({
+      chunkDelayInMs: 500,
+      initialDelayInMs: 1000,
+      chunks: getResponseChunksByPrompt(prompt, true),
+    }),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+  }),
+});
+
+export const titleModel = new MockLanguageModelV2({
+  doGenerate: async () => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    finishReason: "stop",
+    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    content: [{ type: "text", text: "This is a test title" }],
+    warnings: [],
+  }),
+  doStream: async () => ({
+    stream: simulateReadableStream({
+      chunkDelayInMs: 500,
+      initialDelayInMs: 1000,
+      chunks: [
+        { id: "1", type: "text-start" },
+        { id: "1", type: "text-delta", delta: "This is a test title" },
+        { id: "1", type: "text-end" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 3, outputTokens: 10, totalTokens: 13 },
+        },
+      ],
+    }),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+  }),
+});
+
+export const artifactModel = new MockLanguageModelV2({
+  doGenerate: async () => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    finishReason: "stop",
+    usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+    content: [{ type: "text", text: "Hello, world!" }],
+    warnings: [],
+  }),
+  doStream: async ({ prompt }) => ({
+    stream: simulateReadableStream({
+      chunkDelayInMs: 50,
+      initialDelayInMs: 100,
+      chunks: getResponseChunksByPrompt(prompt),
+    }),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+  }),
+});

--- a/packages/ai_frontend/lib/ai/models.ts
+++ b/packages/ai_frontend/lib/ai/models.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_CHAT_MODEL: string = "chat-model";
+
+export type ChatModel = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+export const chatModels: ChatModel[] = [
+  {
+    id: "chat-model",
+    name: "Grok Vision",
+    description: "Advanced multimodal model with vision and text capabilities",
+  },
+  {
+    id: "chat-model-reasoning",
+    name: "Grok Reasoning",
+    description:
+      "Uses advanced chain-of-thought reasoning for complex problems",
+  },
+];

--- a/packages/ai_frontend/lib/ai/prompts.ts
+++ b/packages/ai_frontend/lib/ai/prompts.ts
@@ -1,0 +1,114 @@
+import type { Geo } from "@vercel/functions";
+import type { ArtifactKind } from "@/components/artifact";
+
+export const artifactsPrompt = `
+Artifacts is a special user interface mode that helps users with writing, editing, and other content creation tasks. When artifact is open, it is on the right side of the screen, while the conversation is on the left side. When creating or updating documents, changes are reflected in real-time on the artifacts and visible to the user.
+
+When asked to write code, always use artifacts. When writing code, specify the language in the backticks, e.g. \`\`\`python\`code here\`\`\`. The default language is Python. Other languages are not yet supported, so let the user know if they request a different language.
+
+DO NOT UPDATE DOCUMENTS IMMEDIATELY AFTER CREATING THEM. WAIT FOR USER FEEDBACK OR REQUEST TO UPDATE IT.
+
+This is a guide for using artifacts tools: \`createDocument\` and \`updateDocument\`, which render content on a artifacts beside the conversation.
+
+**When to use \`createDocument\`:**
+- For substantial content (>10 lines) or code
+- For content users will likely save/reuse (emails, code, essays, etc.)
+- When explicitly requested to create a document
+- For when content contains a single code snippet
+
+**When NOT to use \`createDocument\`:**
+- For informational/explanatory content
+- For conversational responses
+- When asked to keep it in chat
+
+**Using \`updateDocument\`:**
+- Default to full document rewrites for major changes
+- Use targeted updates only for specific, isolated changes
+- Follow user instructions for which parts to modify
+
+**When NOT to use \`updateDocument\`:**
+- Immediately after creating a document
+
+Do not update document right after creating it. Wait for user feedback or request to update it.
+`;
+
+export const regularPrompt =
+  "You are a friendly assistant! Keep your responses concise and helpful.";
+
+export type RequestHints = {
+  latitude: Geo["latitude"];
+  longitude: Geo["longitude"];
+  city: Geo["city"];
+  country: Geo["country"];
+};
+
+export const getRequestPromptFromHints = (requestHints: RequestHints) => `\
+About the origin of user's request:
+- lat: ${requestHints.latitude}
+- lon: ${requestHints.longitude}
+- city: ${requestHints.city}
+- country: ${requestHints.country}
+`;
+
+export const systemPrompt = ({
+  selectedChatModel,
+  requestHints,
+}: {
+  selectedChatModel: string;
+  requestHints: RequestHints;
+}) => {
+  const requestPrompt = getRequestPromptFromHints(requestHints);
+
+  if (selectedChatModel === "chat-model-reasoning") {
+    return `${regularPrompt}\n\n${requestPrompt}`;
+  }
+
+  return `${regularPrompt}\n\n${requestPrompt}\n\n${artifactsPrompt}`;
+};
+
+export const codePrompt = `
+You are a Python code generator that creates self-contained, executable code snippets. When writing code:
+
+1. Each snippet should be complete and runnable on its own
+2. Prefer using print() statements to display outputs
+3. Include helpful comments explaining the code
+4. Keep snippets concise (generally under 15 lines)
+5. Avoid external dependencies - use Python standard library
+6. Handle potential errors gracefully
+7. Return meaningful output that demonstrates the code's functionality
+8. Don't use input() or other interactive functions
+9. Don't access files or network resources
+10. Don't use infinite loops
+
+Examples of good snippets:
+
+# Calculate factorial iteratively
+def factorial(n):
+    result = 1
+    for i in range(1, n + 1):
+        result *= i
+    return result
+
+print(f"Factorial of 5 is: {factorial(5)}")
+`;
+
+export const sheetPrompt = `
+You are a spreadsheet creation assistant. Create a spreadsheet in csv format based on the given prompt. The spreadsheet should contain meaningful column headers and data.
+`;
+
+export const updateDocumentPrompt = (
+  currentContent: string | null,
+  type: ArtifactKind
+) => {
+  let mediaType = "document";
+
+  if (type === "code") {
+    mediaType = "code snippet";
+  } else if (type === "sheet") {
+    mediaType = "spreadsheet";
+  }
+
+  return `Improve the following contents of the ${mediaType} based on the given prompt.
+
+${currentContent}`;
+};

--- a/packages/ai_frontend/lib/ai/providers.ts
+++ b/packages/ai_frontend/lib/ai/providers.ts
@@ -1,0 +1,36 @@
+import { gateway } from "@ai-sdk/gateway";
+import {
+  customProvider,
+  extractReasoningMiddleware,
+  wrapLanguageModel,
+} from "ai";
+import { isTestEnvironment } from "../constants";
+
+export const myProvider = isTestEnvironment
+  ? (() => {
+      const {
+        artifactModel,
+        chatModel,
+        reasoningModel,
+        titleModel,
+      } = require("./models.mock");
+      return customProvider({
+        languageModels: {
+          "chat-model": chatModel,
+          "chat-model-reasoning": reasoningModel,
+          "title-model": titleModel,
+          "artifact-model": artifactModel,
+        },
+      });
+    })()
+  : customProvider({
+      languageModels: {
+        "chat-model": gateway.languageModel("xai/grok-2-vision-1212"),
+        "chat-model-reasoning": wrapLanguageModel({
+          model: gateway.languageModel("xai/grok-3-mini"),
+          middleware: extractReasoningMiddleware({ tagName: "think" }),
+        }),
+        "title-model": gateway.languageModel("xai/grok-2-1212"),
+        "artifact-model": gateway.languageModel("xai/grok-2-1212"),
+      },
+    });

--- a/packages/ai_frontend/lib/ai/providers.ts
+++ b/packages/ai_frontend/lib/ai/providers.ts
@@ -1,10 +1,29 @@
-import { gateway } from "@ai-sdk/gateway";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import {
   customProvider,
   extractReasoningMiddleware,
   wrapLanguageModel,
 } from "ai";
 import { isTestEnvironment } from "../constants";
+
+const gatewayProvider = (() => {
+  const baseURL =
+    process.env.OPENAI_COMPATIBLE_BASE_URL ?? "http://127.0.0.1:8080/v1";
+
+  return createOpenAICompatible({
+    name: "law-gateway",
+    baseURL,
+    apiKey: process.env.OPENAI_COMPATIBLE_API_KEY ?? undefined,
+  });
+})();
+
+const chatModelId = process.env.OPENAI_COMPATIBLE_MODEL ?? "law-gateway";
+const reasoningModelId =
+  process.env.OPENAI_COMPATIBLE_REASONING_MODEL ?? chatModelId;
+const titleModelId =
+  process.env.OPENAI_COMPATIBLE_TITLE_MODEL ?? chatModelId;
+const artifactModelId =
+  process.env.OPENAI_COMPATIBLE_ARTIFACT_MODEL ?? chatModelId;
 
 export const myProvider = isTestEnvironment
   ? (() => {
@@ -25,12 +44,12 @@ export const myProvider = isTestEnvironment
     })()
   : customProvider({
       languageModels: {
-        "chat-model": gateway.languageModel("xai/grok-2-vision-1212"),
+        "chat-model": gatewayProvider.chatModel(chatModelId),
         "chat-model-reasoning": wrapLanguageModel({
-          model: gateway.languageModel("xai/grok-3-mini"),
+          model: gatewayProvider.chatModel(reasoningModelId),
           middleware: extractReasoningMiddleware({ tagName: "think" }),
         }),
-        "title-model": gateway.languageModel("xai/grok-2-1212"),
-        "artifact-model": gateway.languageModel("xai/grok-2-1212"),
+        "title-model": gatewayProvider.chatModel(titleModelId),
+        "artifact-model": gatewayProvider.chatModel(artifactModelId),
       },
     });

--- a/packages/ai_frontend/lib/ai/tools/create-document.ts
+++ b/packages/ai_frontend/lib/ai/tools/create-document.ts
@@ -1,0 +1,76 @@
+import { tool, type UIMessageStreamWriter } from "ai";
+import type { Session } from "next-auth";
+import { z } from "zod";
+import {
+  artifactKinds,
+  documentHandlersByArtifactKind,
+} from "@/lib/artifacts/server";
+import type { ChatMessage } from "@/lib/types";
+import { generateUUID } from "@/lib/utils";
+
+type CreateDocumentProps = {
+  session: Session;
+  dataStream: UIMessageStreamWriter<ChatMessage>;
+};
+
+export const createDocument = ({ session, dataStream }: CreateDocumentProps) =>
+  tool({
+    description:
+      "Create a document for a writing or content creation activities. This tool will call other functions that will generate the contents of the document based on the title and kind.",
+    inputSchema: z.object({
+      title: z.string(),
+      kind: z.enum(artifactKinds),
+    }),
+    execute: async ({ title, kind }) => {
+      const id = generateUUID();
+
+      dataStream.write({
+        type: "data-kind",
+        data: kind,
+        transient: true,
+      });
+
+      dataStream.write({
+        type: "data-id",
+        data: id,
+        transient: true,
+      });
+
+      dataStream.write({
+        type: "data-title",
+        data: title,
+        transient: true,
+      });
+
+      dataStream.write({
+        type: "data-clear",
+        data: null,
+        transient: true,
+      });
+
+      const documentHandler = documentHandlersByArtifactKind.find(
+        (documentHandlerByArtifactKind) =>
+          documentHandlerByArtifactKind.kind === kind
+      );
+
+      if (!documentHandler) {
+        throw new Error(`No document handler found for kind: ${kind}`);
+      }
+
+      await documentHandler.onCreateDocument({
+        id,
+        title,
+        dataStream,
+        session,
+      });
+
+      dataStream.write({ type: "data-finish", data: null, transient: true });
+
+      return {
+        id,
+        title,
+        kind,
+        content: "A document was created and is now visible to the user.",
+      };
+    },
+  });

--- a/packages/ai_frontend/lib/ai/tools/get-weather.ts
+++ b/packages/ai_frontend/lib/ai/tools/get-weather.ts
@@ -1,0 +1,18 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export const getWeather = tool({
+  description: "Get the current weather at a location",
+  inputSchema: z.object({
+    latitude: z.number(),
+    longitude: z.number(),
+  }),
+  execute: async ({ latitude, longitude }) => {
+    const response = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m&hourly=temperature_2m&daily=sunrise,sunset&timezone=auto`
+    );
+
+    const weatherData = await response.json();
+    return weatherData;
+  },
+});

--- a/packages/ai_frontend/lib/ai/tools/get-weather.ts
+++ b/packages/ai_frontend/lib/ai/tools/get-weather.ts
@@ -12,7 +12,6 @@ export const getWeather = tool({
       `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m&hourly=temperature_2m&daily=sunrise,sunset&timezone=auto`
     );
 
-    const weatherData = await response.json();
-    return weatherData;
+    return await response.json();
   },
 });

--- a/packages/ai_frontend/lib/ai/tools/request-suggestions.ts
+++ b/packages/ai_frontend/lib/ai/tools/request-suggestions.ts
@@ -1,0 +1,93 @@
+import { streamObject, tool, type UIMessageStreamWriter } from "ai";
+import type { Session } from "next-auth";
+import { z } from "zod";
+import { getDocumentById, saveSuggestions } from "@/lib/db/queries";
+import type { Suggestion } from "@/lib/db/schema";
+import type { ChatMessage } from "@/lib/types";
+import { generateUUID } from "@/lib/utils";
+import { myProvider } from "../providers";
+
+type RequestSuggestionsProps = {
+  session: Session;
+  dataStream: UIMessageStreamWriter<ChatMessage>;
+};
+
+export const requestSuggestions = ({
+  session,
+  dataStream,
+}: RequestSuggestionsProps) =>
+  tool({
+    description: "Request suggestions for a document",
+    inputSchema: z.object({
+      documentId: z
+        .string()
+        .describe("The ID of the document to request edits"),
+    }),
+    execute: async ({ documentId }) => {
+      const document = await getDocumentById({ id: documentId });
+
+      if (!document || !document.content) {
+        return {
+          error: "Document not found",
+        };
+      }
+
+      const suggestions: Omit<
+        Suggestion,
+        "userId" | "createdAt" | "documentCreatedAt"
+      >[] = [];
+
+      const { elementStream } = streamObject({
+        model: myProvider.languageModel("artifact-model"),
+        system:
+          "You are a help writing assistant. Given a piece of writing, please offer suggestions to improve the piece of writing and describe the change. It is very important for the edits to contain full sentences instead of just words. Max 5 suggestions.",
+        prompt: document.content,
+        output: "array",
+        schema: z.object({
+          originalSentence: z.string().describe("The original sentence"),
+          suggestedSentence: z.string().describe("The suggested sentence"),
+          description: z.string().describe("The description of the suggestion"),
+        }),
+      });
+
+      for await (const element of elementStream) {
+        // @ts-expect-error todo: fix type
+        const suggestion: Suggestion = {
+          originalText: element.originalSentence,
+          suggestedText: element.suggestedSentence,
+          description: element.description,
+          id: generateUUID(),
+          documentId,
+          isResolved: false,
+        };
+
+        dataStream.write({
+          type: "data-suggestion",
+          data: suggestion,
+          transient: true,
+        });
+
+        suggestions.push(suggestion);
+      }
+
+      if (session.user?.id) {
+        const userId = session.user.id;
+
+        await saveSuggestions({
+          suggestions: suggestions.map((suggestion) => ({
+            ...suggestion,
+            userId,
+            createdAt: new Date(),
+            documentCreatedAt: document.createdAt,
+          })),
+        });
+      }
+
+      return {
+        id: documentId,
+        title: document.title,
+        kind: document.kind,
+        message: "Suggestions have been added to the document",
+      };
+    },
+  });

--- a/packages/ai_frontend/lib/ai/tools/update-document.ts
+++ b/packages/ai_frontend/lib/ai/tools/update-document.ts
@@ -1,0 +1,62 @@
+import { tool, type UIMessageStreamWriter } from "ai";
+import type { Session } from "next-auth";
+import { z } from "zod";
+import { documentHandlersByArtifactKind } from "@/lib/artifacts/server";
+import { getDocumentById } from "@/lib/db/queries";
+import type { ChatMessage } from "@/lib/types";
+
+type UpdateDocumentProps = {
+  session: Session;
+  dataStream: UIMessageStreamWriter<ChatMessage>;
+};
+
+export const updateDocument = ({ session, dataStream }: UpdateDocumentProps) =>
+  tool({
+    description: "Update a document with the given description.",
+    inputSchema: z.object({
+      id: z.string().describe("The ID of the document to update"),
+      description: z
+        .string()
+        .describe("The description of changes that need to be made"),
+    }),
+    execute: async ({ id, description }) => {
+      const document = await getDocumentById({ id });
+
+      if (!document) {
+        return {
+          error: "Document not found",
+        };
+      }
+
+      dataStream.write({
+        type: "data-clear",
+        data: null,
+        transient: true,
+      });
+
+      const documentHandler = documentHandlersByArtifactKind.find(
+        (documentHandlerByArtifactKind) =>
+          documentHandlerByArtifactKind.kind === document.kind
+      );
+
+      if (!documentHandler) {
+        throw new Error(`No document handler found for kind: ${document.kind}`);
+      }
+
+      await documentHandler.onUpdateDocument({
+        document,
+        description,
+        dataStream,
+        session,
+      });
+
+      dataStream.write({ type: "data-finish", data: null, transient: true });
+
+      return {
+        id,
+        title: document.title,
+        kind: document.kind,
+        content: "The document has been updated successfully.",
+      };
+    },
+  });

--- a/packages/ai_frontend/lib/artifacts/server.ts
+++ b/packages/ai_frontend/lib/artifacts/server.ts
@@ -1,0 +1,98 @@
+import type { UIMessageStreamWriter } from "ai";
+import type { Session } from "next-auth";
+import { codeDocumentHandler } from "@/artifacts/code/server";
+import { sheetDocumentHandler } from "@/artifacts/sheet/server";
+import { textDocumentHandler } from "@/artifacts/text/server";
+import type { ArtifactKind } from "@/components/artifact";
+import { saveDocument } from "../db/queries";
+import type { Document } from "../db/schema";
+import type { ChatMessage } from "../types";
+
+export type SaveDocumentProps = {
+  id: string;
+  title: string;
+  kind: ArtifactKind;
+  content: string;
+  userId: string;
+};
+
+export type CreateDocumentCallbackProps = {
+  id: string;
+  title: string;
+  dataStream: UIMessageStreamWriter<ChatMessage>;
+  session: Session;
+};
+
+export type UpdateDocumentCallbackProps = {
+  document: Document;
+  description: string;
+  dataStream: UIMessageStreamWriter<ChatMessage>;
+  session: Session;
+};
+
+export type DocumentHandler<T = ArtifactKind> = {
+  kind: T;
+  onCreateDocument: (args: CreateDocumentCallbackProps) => Promise<void>;
+  onUpdateDocument: (args: UpdateDocumentCallbackProps) => Promise<void>;
+};
+
+export function createDocumentHandler<T extends ArtifactKind>(config: {
+  kind: T;
+  onCreateDocument: (params: CreateDocumentCallbackProps) => Promise<string>;
+  onUpdateDocument: (params: UpdateDocumentCallbackProps) => Promise<string>;
+}): DocumentHandler<T> {
+  return {
+    kind: config.kind,
+    onCreateDocument: async (args: CreateDocumentCallbackProps) => {
+      const draftContent = await config.onCreateDocument({
+        id: args.id,
+        title: args.title,
+        dataStream: args.dataStream,
+        session: args.session,
+      });
+
+      if (args.session?.user?.id) {
+        await saveDocument({
+          id: args.id,
+          title: args.title,
+          content: draftContent,
+          kind: config.kind,
+          userId: args.session.user.id,
+        });
+      }
+
+      return;
+    },
+    onUpdateDocument: async (args: UpdateDocumentCallbackProps) => {
+      const draftContent = await config.onUpdateDocument({
+        document: args.document,
+        description: args.description,
+        dataStream: args.dataStream,
+        session: args.session,
+      });
+
+      if (args.session?.user?.id) {
+        await saveDocument({
+          id: args.document.id,
+          title: args.document.title,
+          content: draftContent,
+          kind: config.kind,
+          userId: args.session.user.id,
+        });
+      }
+
+      return;
+    },
+  };
+}
+
+/*
+ * Use this array to define the document handlers for each artifact kind.
+ */
+export const documentHandlersByArtifactKind: DocumentHandler[] = [
+  textDocumentHandler,
+  codeDocumentHandler,
+  sheetDocumentHandler,
+];
+
+export const artifactKinds = ["text", "code", "sheet"] as const;

--- a/packages/ai_frontend/lib/constants.ts
+++ b/packages/ai_frontend/lib/constants.ts
@@ -1,0 +1,13 @@
+import { generateDummyPassword } from "./db/utils";
+
+export const isProductionEnvironment = process.env.NODE_ENV === "production";
+export const isDevelopmentEnvironment = process.env.NODE_ENV === "development";
+export const isTestEnvironment = Boolean(
+  process.env.PLAYWRIGHT_TEST_BASE_URL ||
+    process.env.PLAYWRIGHT ||
+    process.env.CI_PLAYWRIGHT
+);
+
+export const guestRegex = /^guest-\d+$/;
+
+export const DUMMY_PASSWORD = generateDummyPassword();

--- a/packages/ai_frontend/lib/db/client.ts
+++ b/packages/ai_frontend/lib/db/client.ts
@@ -30,7 +30,7 @@ export const getDb = () => {
   return db;
 };
 
-export const createScopedDb = (options?: Options<Record<string, unknown>>) => {
+export const createScopedDb = (options?: Options) => {
   ensureServerEnvironment();
   const scopedClient = postgres(getPostgresUrl(), options);
   return { db: drizzle(scopedClient), client: scopedClient };

--- a/packages/ai_frontend/lib/db/client.ts
+++ b/packages/ai_frontend/lib/db/client.ts
@@ -1,14 +1,19 @@
-import "server-only";
-
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres, { type Options, type Sql } from "postgres";
 
 import { getPostgresUrl } from "./env";
 
+const ensureServerEnvironment = () => {
+  if (typeof window !== "undefined") {
+    throw new Error("Database client can only be used on the server");
+  }
+};
+
 let client: Sql<Record<string, unknown>> | undefined;
 let db: ReturnType<typeof drizzle> | undefined;
 
 export const getPostgresClient = () => {
+  ensureServerEnvironment();
   if (!client) {
     client = postgres(getPostgresUrl());
   }
@@ -17,6 +22,7 @@ export const getPostgresClient = () => {
 };
 
 export const getDb = () => {
+  ensureServerEnvironment();
   if (!db) {
     db = drizzle(getPostgresClient());
   }
@@ -25,6 +31,7 @@ export const getDb = () => {
 };
 
 export const createScopedDb = (options?: Options<Record<string, unknown>>) => {
+  ensureServerEnvironment();
   const scopedClient = postgres(getPostgresUrl(), options);
   return { db: drizzle(scopedClient), client: scopedClient };
 };

--- a/packages/ai_frontend/lib/db/client.ts
+++ b/packages/ai_frontend/lib/db/client.ts
@@ -9,7 +9,9 @@ const ensureServerEnvironment = () => {
   }
 };
 
-let client: Sql<Record<string, unknown>> | undefined;
+type PostgresRow = Record<string, unknown>;
+
+let client: Sql<PostgresRow> | undefined;
 let db: ReturnType<typeof drizzle> | undefined;
 
 export const getPostgresClient = () => {
@@ -30,7 +32,7 @@ export const getDb = () => {
   return db;
 };
 
-export const createScopedDb = (options?: Options) => {
+export const createScopedDb = (options?: Options<PostgresRow>) => {
   ensureServerEnvironment();
   const scopedClient = postgres(getPostgresUrl(), options);
   return { db: drizzle(scopedClient), client: scopedClient };

--- a/packages/ai_frontend/lib/db/client.ts
+++ b/packages/ai_frontend/lib/db/client.ts
@@ -9,9 +9,7 @@ const ensureServerEnvironment = () => {
   }
 };
 
-type PostgresRow = Record<string, unknown>;
-
-let client: Sql<PostgresRow> | undefined;
+let client: Sql | undefined;
 let db: ReturnType<typeof drizzle> | undefined;
 
 export const getPostgresClient = () => {
@@ -32,7 +30,7 @@ export const getDb = () => {
   return db;
 };
 
-export const createScopedDb = (options?: Options<PostgresRow>) => {
+export const createScopedDb = (options?: Options) => {
   ensureServerEnvironment();
   const scopedClient = postgres(getPostgresUrl(), options);
   return { db: drizzle(scopedClient), client: scopedClient };

--- a/packages/ai_frontend/lib/db/client.ts
+++ b/packages/ai_frontend/lib/db/client.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres, { type Options, type Sql } from "postgres";
+
+import { getPostgresUrl } from "./env";
+
+let client: Sql<Record<string, unknown>> | undefined;
+let db: ReturnType<typeof drizzle> | undefined;
+
+export const getPostgresClient = () => {
+  if (!client) {
+    client = postgres(getPostgresUrl());
+  }
+
+  return client;
+};
+
+export const getDb = () => {
+  if (!db) {
+    db = drizzle(getPostgresClient());
+  }
+
+  return db;
+};
+
+export const createScopedDb = (options?: Options<Record<string, unknown>>) => {
+  const scopedClient = postgres(getPostgresUrl(), options);
+  return { db: drizzle(scopedClient), client: scopedClient };
+};

--- a/packages/ai_frontend/lib/db/env.ts
+++ b/packages/ai_frontend/lib/db/env.ts
@@ -1,0 +1,11 @@
+export function getPostgresUrl(): string {
+  const { POSTGRES_URL } = process.env;
+
+  if (!POSTGRES_URL) {
+    throw new Error(
+      "POSTGRES_URL environment variable is required to access the database"
+    );
+  }
+
+  return POSTGRES_URL;
+}

--- a/packages/ai_frontend/lib/db/helpers/01-core-to-parts.ts
+++ b/packages/ai_frontend/lib/db/helpers/01-core-to-parts.ts
@@ -1,0 +1,253 @@
+// This is a helper for an older version of ai, v4.3.13
+
+// import { config } from 'dotenv';
+// import postgres from 'postgres';
+// import {
+//   chat,
+//   message,
+//   type MessageDeprecated,
+//   messageDeprecated,
+//   vote,
+//   voteDeprecated,
+// } from '../schema';
+// import { drizzle } from 'drizzle-orm/postgres-js';
+// import { inArray } from 'drizzle-orm';
+// import { appendResponseMessages, type UIMessage } from 'ai';
+
+// config({
+//   path: '.env.local',
+// });
+
+// if (!process.env.POSTGRES_URL) {
+//   throw new Error('POSTGRES_URL environment variable is not set');
+// }
+
+// const client = postgres(process.env.POSTGRES_URL);
+// const db = drizzle(client);
+
+// const BATCH_SIZE = 100; // Process 100 chats at a time
+// const INSERT_BATCH_SIZE = 1000; // Insert 1000 messages at a time
+
+// type NewMessageInsert = {
+//   id: string;
+//   chatId: string;
+//   parts: any[];
+//   role: string;
+//   attachments: any[];
+//   createdAt: Date;
+// };
+
+// type NewVoteInsert = {
+//   messageId: string;
+//   chatId: string;
+//   isUpvoted: boolean;
+// };
+
+// interface MessageDeprecatedContentPart {
+//   type: string;
+//   content: unknown;
+// }
+
+// function getMessageRank(message: MessageDeprecated): number {
+//   if (
+//     message.role === 'assistant' &&
+//     (message.content as MessageDeprecatedContentPart[]).some(
+//       (contentPart) => contentPart.type === 'tool-call',
+//     )
+//   ) {
+//     return 0;
+//   }
+
+//   if (
+//     message.role === 'tool' &&
+//     (message.content as MessageDeprecatedContentPart[]).some(
+//       (contentPart) => contentPart.type === 'tool-result',
+//     )
+//   ) {
+//     return 1;
+//   }
+
+//   if (message.role === 'assistant') {
+//     return 2;
+//   }
+
+//   return 3;
+// }
+
+// function dedupeParts<T extends { type: string; [k: string]: any }>(
+//   parts: T[],
+// ): T[] {
+//   const seen = new Set<string>();
+//   return parts.filter((p) => {
+//     const key = `${p.type}|${JSON.stringify(p.content ?? p)}`;
+//     if (seen.has(key)) return false;
+//     seen.add(key);
+//     return true;
+//   });
+// }
+
+// function sanitizeParts<T extends { type: string; [k: string]: any }>(
+//   parts: T[],
+// ): T[] {
+//   return parts.filter(
+//     (part) => !(part.type === 'reasoning' && part.reasoning === 'undefined'),
+//   );
+// }
+
+// async function migrateMessages() {
+//   const chats = await db.select().from(chat);
+
+//   let processedCount = 0;
+
+//   for (let i = 0; i < chats.length; i += BATCH_SIZE) {
+//     const chatBatch = chats.slice(i, i + BATCH_SIZE);
+//     const chatIds = chatBatch.map((chat) => chat.id);
+
+//     const allMessages = await db
+//       .select()
+//       .from(messageDeprecated)
+//       .where(inArray(messageDeprecated.chatId, chatIds));
+
+//     const allVotes = await db
+//       .select()
+//       .from(voteDeprecated)
+//       .where(inArray(voteDeprecated.chatId, chatIds));
+
+//     const newMessagesToInsert: NewMessageInsert[] = [];
+//     const newVotesToInsert: NewVoteInsert[] = [];
+
+//     for (const chat of chatBatch) {
+//       processedCount++;
+//       console.info(`Processed ${processedCount}/${chats.length} chats`);
+
+//       const messages = allMessages
+//         .filter((message) => message.chatId === chat.id)
+//         .sort((a, b) => {
+//           const differenceInTime =
+//             new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+//           if (differenceInTime !== 0) return differenceInTime;
+
+//           return getMessageRank(a) - getMessageRank(b);
+//         });
+
+//       const votes = allVotes.filter((v) => v.chatId === chat.id);
+
+//       const messageSection: Array<UIMessage> = [];
+//       const messageSections: Array<Array<UIMessage>> = [];
+
+//       for (const message of messages) {
+//         const { role } = message;
+
+//         if (role === 'user' && messageSection.length > 0) {
+//           messageSections.push([...messageSection]);
+//           messageSection.length = 0;
+//         }
+
+//         // @ts-expect-error message.content has different type
+//         messageSection.push(message);
+//       }
+
+//       if (messageSection.length > 0) {
+//         messageSections.push([...messageSection]);
+//       }
+
+//       for (const section of messageSections) {
+//         const [userMessage, ...assistantMessages] = section;
+
+//         const [firstAssistantMessage] = assistantMessages;
+
+//         try {
+//           const uiSection = appendResponseMessages({
+//             messages: [userMessage],
+//             // @ts-expect-error: message.content has different type
+//             responseMessages: assistantMessages,
+//             _internal: {
+//               currentDate: () => firstAssistantMessage.createdAt ?? new Date(),
+//             },
+//           });
+
+//           const projectedUISection = uiSection
+//             .map((message) => {
+//               if (message.role === 'user') {
+//                 return {
+//                   id: message.id,
+//                   chatId: chat.id,
+//                   parts: [{ type: 'text', text: message.content }],
+//                   role: message.role,
+//                   createdAt: message.createdAt,
+//                   attachments: [],
+//                 } as NewMessageInsert;
+//               } else if (message.role === 'assistant') {
+//                 const cleanParts = sanitizeParts(
+//                   dedupeParts(message.parts || []),
+//                 );
+
+//                 return {
+//                   id: message.id,
+//                   chatId: chat.id,
+//                   parts: cleanParts,
+//                   role: message.role,
+//                   createdAt: message.createdAt,
+//                   attachments: [],
+//                 } as NewMessageInsert;
+//               }
+//               return null;
+//             })
+//             .filter((msg): msg is NewMessageInsert => msg !== null);
+
+//           for (const msg of projectedUISection) {
+//             newMessagesToInsert.push(msg);
+
+//             if (msg.role === 'assistant') {
+//               const voteByMessage = votes.find((v) => v.messageId === msg.id);
+//               if (voteByMessage) {
+//                 newVotesToInsert.push({
+//                   messageId: msg.id,
+//                   chatId: msg.chatId,
+//                   isUpvoted: voteByMessage.isUpvoted,
+//                 });
+//               }
+//             }
+//           }
+//         } catch (error) {
+//           console.error(`Error processing chat ${chat.id}: ${error}`);
+//         }
+//       }
+//     }
+
+//     for (let j = 0; j < newMessagesToInsert.length; j += INSERT_BATCH_SIZE) {
+//       const messageBatch = newMessagesToInsert.slice(j, j + INSERT_BATCH_SIZE);
+//       if (messageBatch.length > 0) {
+//         const validMessageBatch = messageBatch.map((msg) => ({
+//           id: msg.id,
+//           chatId: msg.chatId,
+//           parts: msg.parts,
+//           role: msg.role,
+//           attachments: msg.attachments,
+//           createdAt: msg.createdAt,
+//         }));
+
+//         await db.insert(message).values(validMessageBatch);
+//       }
+//     }
+
+//     for (let j = 0; j < newVotesToInsert.length; j += INSERT_BATCH_SIZE) {
+//       const voteBatch = newVotesToInsert.slice(j, j + INSERT_BATCH_SIZE);
+//       if (voteBatch.length > 0) {
+//         await db.insert(vote).values(voteBatch);
+//       }
+//     }
+//   }
+
+//   console.info(`Migration completed: ${processedCount} chats processed`);
+// }
+
+// migrateMessages()
+//   .then(() => {
+//     console.info('Script completed successfully');
+//     process.exit(0);
+//   })
+//   .catch((error) => {
+//     console.error('Script failed:', error);
+//     process.exit(1);
+//   });

--- a/packages/ai_frontend/lib/db/migrate.ts
+++ b/packages/ai_frontend/lib/db/migrate.ts
@@ -1,0 +1,32 @@
+import { config } from "dotenv";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import postgres from "postgres";
+
+config({
+  path: ".env.local",
+});
+
+const runMigrate = async () => {
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("POSTGRES_URL is not defined");
+  }
+
+  const connection = postgres(process.env.POSTGRES_URL, { max: 1 });
+  const db = drizzle(connection);
+
+  console.log("⏳ Running migrations...");
+
+  const start = Date.now();
+  await migrate(db, { migrationsFolder: "./lib/db/migrations" });
+  const end = Date.now();
+
+  console.log("✅ Migrations completed in", end - start, "ms");
+  process.exit(0);
+};
+
+runMigrate().catch((err) => {
+  console.error("❌ Migration failed");
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/ai_frontend/lib/db/migrate.ts
+++ b/packages/ai_frontend/lib/db/migrate.ts
@@ -1,19 +1,14 @@
 import { config } from "dotenv";
-import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
-import postgres from "postgres";
+
+import { createScopedDb } from "./client";
 
 config({
   path: ".env.local",
 });
 
 const runMigrate = async () => {
-  if (!process.env.POSTGRES_URL) {
-    throw new Error("POSTGRES_URL is not defined");
-  }
-
-  const connection = postgres(process.env.POSTGRES_URL, { max: 1 });
-  const db = drizzle(connection);
+  const { db, client } = createScopedDb({ max: 1 });
 
   console.log("⏳ Running migrations...");
 
@@ -22,6 +17,7 @@ const runMigrate = async () => {
   const end = Date.now();
 
   console.log("✅ Migrations completed in", end - start, "ms");
+  await client.end();
   process.exit(0);
 };
 

--- a/packages/ai_frontend/lib/db/migrations/0000_keen_devos.sql
+++ b/packages/ai_frontend/lib/db/migrations/0000_keen_devos.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "Chat" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"createdAt" timestamp NOT NULL,
+	"messages" json NOT NULL,
+	"userId" uuid NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "User" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" varchar(64) NOT NULL,
+	"password" varchar(64)
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Chat" ADD CONSTRAINT "Chat_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/ai_frontend/lib/db/migrations/0001_sparkling_blue_marvel.sql
+++ b/packages/ai_frontend/lib/db/migrations/0001_sparkling_blue_marvel.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS "Suggestion" (
+	"id" uuid DEFAULT gen_random_uuid() NOT NULL,
+	"documentId" uuid NOT NULL,
+	"documentCreatedAt" timestamp NOT NULL,
+	"originalText" text NOT NULL,
+	"suggestedText" text NOT NULL,
+	"description" text,
+	"isResolved" boolean DEFAULT false NOT NULL,
+	"userId" uuid NOT NULL,
+	"createdAt" timestamp NOT NULL,
+	CONSTRAINT "Suggestion_id_pk" PRIMARY KEY("id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "Document" (
+	"id" uuid DEFAULT gen_random_uuid() NOT NULL,
+	"createdAt" timestamp NOT NULL,
+	"title" text NOT NULL,
+	"content" text,
+	"userId" uuid NOT NULL,
+	CONSTRAINT "Document_id_createdAt_pk" PRIMARY KEY("id","createdAt")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Suggestion" ADD CONSTRAINT "Suggestion_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Suggestion" ADD CONSTRAINT "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk" FOREIGN KEY ("documentId","documentCreatedAt") REFERENCES "public"."Document"("id","createdAt") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Document" ADD CONSTRAINT "Document_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/ai_frontend/lib/db/migrations/0002_wandering_riptide.sql
+++ b/packages/ai_frontend/lib/db/migrations/0002_wandering_riptide.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS "Message" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chatId" uuid NOT NULL,
+	"role" varchar NOT NULL,
+	"content" json NOT NULL,
+	"createdAt" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "Vote" (
+	"chatId" uuid NOT NULL,
+	"messageId" uuid NOT NULL,
+	"isUpvoted" boolean NOT NULL,
+	CONSTRAINT "Vote_chatId_messageId_pk" PRIMARY KEY("chatId","messageId")
+);
+--> statement-breakpoint
+ALTER TABLE "Chat" ADD COLUMN "title" text NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Message" ADD CONSTRAINT "Message_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Vote" ADD CONSTRAINT "Vote_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Vote" ADD CONSTRAINT "Vote_messageId_Message_id_fk" FOREIGN KEY ("messageId") REFERENCES "public"."Message"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "Chat" DROP COLUMN IF EXISTS "messages";

--- a/packages/ai_frontend/lib/db/migrations/0003_cloudy_glorian.sql
+++ b/packages/ai_frontend/lib/db/migrations/0003_cloudy_glorian.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Chat" ADD COLUMN "visibility" varchar DEFAULT 'private' NOT NULL;

--- a/packages/ai_frontend/lib/db/migrations/0004_odd_slayback.sql
+++ b/packages/ai_frontend/lib/db/migrations/0004_odd_slayback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Document" ADD COLUMN "text" varchar DEFAULT 'text' NOT NULL;

--- a/packages/ai_frontend/lib/db/migrations/0005_wooden_whistler.sql
+++ b/packages/ai_frontend/lib/db/migrations/0005_wooden_whistler.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS "Message_v2" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chatId" uuid NOT NULL,
+	"role" varchar NOT NULL,
+	"parts" json NOT NULL,
+	"attachments" json NOT NULL,
+	"createdAt" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "Vote_v2" (
+	"chatId" uuid NOT NULL,
+	"messageId" uuid NOT NULL,
+	"isUpvoted" boolean NOT NULL,
+	CONSTRAINT "Vote_v2_chatId_messageId_pk" PRIMARY KEY("chatId","messageId")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Message_v2" ADD CONSTRAINT "Message_v2_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Vote_v2" ADD CONSTRAINT "Vote_v2_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Vote_v2" ADD CONSTRAINT "Vote_v2_messageId_Message_v2_id_fk" FOREIGN KEY ("messageId") REFERENCES "public"."Message_v2"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/ai_frontend/lib/db/migrations/0006_marvelous_frog_thor.sql
+++ b/packages/ai_frontend/lib/db/migrations/0006_marvelous_frog_thor.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "Stream" (
+	"id" uuid DEFAULT gen_random_uuid() NOT NULL,
+	"chatId" uuid NOT NULL,
+	"createdAt" timestamp NOT NULL,
+	CONSTRAINT "Stream_id_pk" PRIMARY KEY("id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Stream" ADD CONSTRAINT "Stream_chatId_Chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/ai_frontend/lib/db/migrations/0007_flowery_ben_parker.sql
+++ b/packages/ai_frontend/lib/db/migrations/0007_flowery_ben_parker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Chat" ADD COLUMN "lastContext" jsonb;

--- a/packages/ai_frontend/lib/db/migrations/meta/0000_snapshot.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,90 @@
+{
+  "id": "715ec9ec-6715-4d0f-9f6c-9b5c7f09827c",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/ai_frontend/lib/db/migrations/meta/0001_snapshot.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,236 @@
+{
+  "id": "f3d3437c-4735-4c91-80af-1014048a904e",
+  "prevId": "715ec9ec-6715-4d0f-9f6c-9b5c7f09827c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId", "documentCreatedAt"],
+          "columnsTo": ["id", "createdAt"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": ["id", "createdAt"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/ai_frontend/lib/db/migrations/meta/0002_snapshot.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,339 @@
+{
+  "id": "b5d8e862-936f-4419-a50f-97be3e7fe665",
+  "prevId": "f3d3437c-4735-4c91-80af-1014048a904e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId", "documentCreatedAt"],
+          "columnsTo": ["id", "createdAt"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": ["id", "createdAt"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/ai_frontend/lib/db/migrations/meta/0003_snapshot.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,346 @@
+{
+  "id": "011efa9e-42c7-4ff6-830a-02106f6638c9",
+  "prevId": "b5d8e862-936f-4419-a50f-97be3e7fe665",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": ["id", "createdAt"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId", "documentCreatedAt"],
+          "columnsTo": ["id", "createdAt"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/ai_frontend/lib/db/migrations/meta/0004_snapshot.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,353 @@
+{
+  "id": "30ad8233-1432-428b-93fc-2bb1ba867ff1",
+  "prevId": "011efa9e-42c7-4ff6-830a-02106f6638c9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": ["id", "createdAt"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId", "documentCreatedAt"],
+          "columnsTo": ["id", "createdAt"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/ai_frontend/lib/db/migrations/meta/0005_snapshot.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,462 @@
+{
+  "id": "c6c102e6-b64e-4f0c-a7a6-32df758de437",
+  "prevId": "30ad8233-1432-428b-93fc-2bb1ba867ff1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": ["id", "createdAt"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId", "documentCreatedAt"],
+          "columnsTo": ["id", "createdAt"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/ai_frontend/lib/db/migrations/meta/0006_snapshot.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,506 @@
+{
+  "id": "443de550-b7e8-4bfb-b229-c12dc6c132f0",
+  "prevId": "c6c102e6-b64e-4f0c-a7a6-32df758de437",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": ["id", "createdAt"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId", "documentCreatedAt"],
+          "columnsTo": ["id", "createdAt"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/ai_frontend/lib/db/migrations/meta/0007_snapshot.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,512 @@
+{
+  "id": "097660a7-976a-4b3e-8ebb-79312e3ece6f",
+  "prevId": "443de550-b7e8-4bfb-b229-c12dc6c132f0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": ["id", "createdAt"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId", "documentCreatedAt"],
+          "columnsTo": ["id", "createdAt"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": ["chatId", "messageId"]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/ai_frontend/lib/db/migrations/meta/_journal.json
+++ b/packages/ai_frontend/lib/db/migrations/meta/_journal.json
@@ -1,0 +1,62 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1728598022383,
+      "tag": "0000_keen_devos",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1730207363999,
+      "tag": "0001_sparkling_blue_marvel",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1730725226313,
+      "tag": "0002_wandering_riptide",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1733403031014,
+      "tag": "0003_cloudy_glorian",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1733945232355,
+      "tag": "0004_odd_slayback",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1741934630596,
+      "tag": "0005_wooden_whistler",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1746118166211,
+      "tag": "0006_marvelous_frog_thor",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1757362773211,
+      "tag": "0007_flowery_ben_parker",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/ai_frontend/lib/db/queries.ts
+++ b/packages/ai_frontend/lib/db/queries.ts
@@ -1,0 +1,562 @@
+import "server-only";
+
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  lt,
+  type SQL,
+} from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import type { ArtifactKind } from "@/components/artifact";
+import type { VisibilityType } from "@/components/visibility-selector";
+import { ChatSDKError } from "../errors";
+import type { AppUsage } from "../usage";
+import { generateUUID } from "../utils";
+import {
+  type Chat,
+  chat,
+  type DBMessage,
+  document,
+  message,
+  type Suggestion,
+  stream,
+  suggestion,
+  type User,
+  user,
+  vote,
+} from "./schema";
+import { generateHashedPassword } from "./utils";
+
+// Optionally, if not using email/pass login, you can
+// use the Drizzle adapter for Auth.js / NextAuth
+// https://authjs.dev/reference/adapter/drizzle
+
+// biome-ignore lint: Forbidden non-null assertion.
+const client = postgres(process.env.POSTGRES_URL!);
+const db = drizzle(client);
+
+export async function getUser(email: string): Promise<User[]> {
+  try {
+    return await db.select().from(user).where(eq(user.email, email));
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get user by email"
+    );
+  }
+}
+
+export async function createUser(email: string, password: string) {
+  const hashedPassword = generateHashedPassword(password);
+
+  try {
+    return await db.insert(user).values({ email, password: hashedPassword });
+  } catch (_error) {
+    throw new ChatSDKError("bad_request:database", "Failed to create user");
+  }
+}
+
+export async function createGuestUser() {
+  const email = `guest-${Date.now()}`;
+  const password = generateHashedPassword(generateUUID());
+
+  try {
+    return await db.insert(user).values({ email, password }).returning({
+      id: user.id,
+      email: user.email,
+    });
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to create guest user"
+    );
+  }
+}
+
+export async function saveChat({
+  id,
+  userId,
+  title,
+  visibility,
+}: {
+  id: string;
+  userId: string;
+  title: string;
+  visibility: VisibilityType;
+}) {
+  try {
+    return await db.insert(chat).values({
+      id,
+      createdAt: new Date(),
+      userId,
+      title,
+      visibility,
+    });
+  } catch (_error) {
+    throw new ChatSDKError("bad_request:database", "Failed to save chat");
+  }
+}
+
+export async function deleteChatById({ id }: { id: string }) {
+  try {
+    await db.delete(vote).where(eq(vote.chatId, id));
+    await db.delete(message).where(eq(message.chatId, id));
+    await db.delete(stream).where(eq(stream.chatId, id));
+
+    const [chatsDeleted] = await db
+      .delete(chat)
+      .where(eq(chat.id, id))
+      .returning();
+    return chatsDeleted;
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to delete chat by id"
+    );
+  }
+}
+
+export async function getChatsByUserId({
+  id,
+  limit,
+  startingAfter,
+  endingBefore,
+}: {
+  id: string;
+  limit: number;
+  startingAfter: string | null;
+  endingBefore: string | null;
+}) {
+  try {
+    const extendedLimit = limit + 1;
+
+    const query = (whereCondition?: SQL<any>) =>
+      db
+        .select()
+        .from(chat)
+        .where(
+          whereCondition
+            ? and(whereCondition, eq(chat.userId, id))
+            : eq(chat.userId, id)
+        )
+        .orderBy(desc(chat.createdAt))
+        .limit(extendedLimit);
+
+    let filteredChats: Chat[] = [];
+
+    if (startingAfter) {
+      const [selectedChat] = await db
+        .select()
+        .from(chat)
+        .where(eq(chat.id, startingAfter))
+        .limit(1);
+
+      if (!selectedChat) {
+        throw new ChatSDKError(
+          "not_found:database",
+          `Chat with id ${startingAfter} not found`
+        );
+      }
+
+      filteredChats = await query(gt(chat.createdAt, selectedChat.createdAt));
+    } else if (endingBefore) {
+      const [selectedChat] = await db
+        .select()
+        .from(chat)
+        .where(eq(chat.id, endingBefore))
+        .limit(1);
+
+      if (!selectedChat) {
+        throw new ChatSDKError(
+          "not_found:database",
+          `Chat with id ${endingBefore} not found`
+        );
+      }
+
+      filteredChats = await query(lt(chat.createdAt, selectedChat.createdAt));
+    } else {
+      filteredChats = await query();
+    }
+
+    const hasMore = filteredChats.length > limit;
+
+    return {
+      chats: hasMore ? filteredChats.slice(0, limit) : filteredChats,
+      hasMore,
+    };
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get chats by user id"
+    );
+  }
+}
+
+export async function getChatById({ id }: { id: string }) {
+  try {
+    const [selectedChat] = await db.select().from(chat).where(eq(chat.id, id));
+    if (!selectedChat) {
+      return null;
+    }
+
+    return selectedChat;
+  } catch (_error) {
+    throw new ChatSDKError("bad_request:database", "Failed to get chat by id");
+  }
+}
+
+export async function saveMessages({ messages }: { messages: DBMessage[] }) {
+  try {
+    return await db.insert(message).values(messages);
+  } catch (_error) {
+    throw new ChatSDKError("bad_request:database", "Failed to save messages");
+  }
+}
+
+export async function getMessagesByChatId({ id }: { id: string }) {
+  try {
+    return await db
+      .select()
+      .from(message)
+      .where(eq(message.chatId, id))
+      .orderBy(asc(message.createdAt));
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get messages by chat id"
+    );
+  }
+}
+
+export async function voteMessage({
+  chatId,
+  messageId,
+  type,
+}: {
+  chatId: string;
+  messageId: string;
+  type: "up" | "down";
+}) {
+  try {
+    const [existingVote] = await db
+      .select()
+      .from(vote)
+      .where(and(eq(vote.messageId, messageId)));
+
+    if (existingVote) {
+      return await db
+        .update(vote)
+        .set({ isUpvoted: type === "up" })
+        .where(and(eq(vote.messageId, messageId), eq(vote.chatId, chatId)));
+    }
+    return await db.insert(vote).values({
+      chatId,
+      messageId,
+      isUpvoted: type === "up",
+    });
+  } catch (_error) {
+    throw new ChatSDKError("bad_request:database", "Failed to vote message");
+  }
+}
+
+export async function getVotesByChatId({ id }: { id: string }) {
+  try {
+    return await db.select().from(vote).where(eq(vote.chatId, id));
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get votes by chat id"
+    );
+  }
+}
+
+export async function saveDocument({
+  id,
+  title,
+  kind,
+  content,
+  userId,
+}: {
+  id: string;
+  title: string;
+  kind: ArtifactKind;
+  content: string;
+  userId: string;
+}) {
+  try {
+    return await db
+      .insert(document)
+      .values({
+        id,
+        title,
+        kind,
+        content,
+        userId,
+        createdAt: new Date(),
+      })
+      .returning();
+  } catch (_error) {
+    throw new ChatSDKError("bad_request:database", "Failed to save document");
+  }
+}
+
+export async function getDocumentsById({ id }: { id: string }) {
+  try {
+    const documents = await db
+      .select()
+      .from(document)
+      .where(eq(document.id, id))
+      .orderBy(asc(document.createdAt));
+
+    return documents;
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get documents by id"
+    );
+  }
+}
+
+export async function getDocumentById({ id }: { id: string }) {
+  try {
+    const [selectedDocument] = await db
+      .select()
+      .from(document)
+      .where(eq(document.id, id))
+      .orderBy(desc(document.createdAt));
+
+    return selectedDocument;
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get document by id"
+    );
+  }
+}
+
+export async function deleteDocumentsByIdAfterTimestamp({
+  id,
+  timestamp,
+}: {
+  id: string;
+  timestamp: Date;
+}) {
+  try {
+    await db
+      .delete(suggestion)
+      .where(
+        and(
+          eq(suggestion.documentId, id),
+          gt(suggestion.documentCreatedAt, timestamp)
+        )
+      );
+
+    return await db
+      .delete(document)
+      .where(and(eq(document.id, id), gt(document.createdAt, timestamp)))
+      .returning();
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to delete documents by id after timestamp"
+    );
+  }
+}
+
+export async function saveSuggestions({
+  suggestions,
+}: {
+  suggestions: Suggestion[];
+}) {
+  try {
+    return await db.insert(suggestion).values(suggestions);
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to save suggestions"
+    );
+  }
+}
+
+export async function getSuggestionsByDocumentId({
+  documentId,
+}: {
+  documentId: string;
+}) {
+  try {
+    return await db
+      .select()
+      .from(suggestion)
+      .where(and(eq(suggestion.documentId, documentId)));
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get suggestions by document id"
+    );
+  }
+}
+
+export async function getMessageById({ id }: { id: string }) {
+  try {
+    return await db.select().from(message).where(eq(message.id, id));
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get message by id"
+    );
+  }
+}
+
+export async function deleteMessagesByChatIdAfterTimestamp({
+  chatId,
+  timestamp,
+}: {
+  chatId: string;
+  timestamp: Date;
+}) {
+  try {
+    const messagesToDelete = await db
+      .select({ id: message.id })
+      .from(message)
+      .where(
+        and(eq(message.chatId, chatId), gte(message.createdAt, timestamp))
+      );
+
+    const messageIds = messagesToDelete.map(
+      (currentMessage) => currentMessage.id
+    );
+
+    if (messageIds.length > 0) {
+      await db
+        .delete(vote)
+        .where(
+          and(eq(vote.chatId, chatId), inArray(vote.messageId, messageIds))
+        );
+
+      return await db
+        .delete(message)
+        .where(
+          and(eq(message.chatId, chatId), inArray(message.id, messageIds))
+        );
+    }
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to delete messages by chat id after timestamp"
+    );
+  }
+}
+
+export async function updateChatVisiblityById({
+  chatId,
+  visibility,
+}: {
+  chatId: string;
+  visibility: "private" | "public";
+}) {
+  try {
+    return await db.update(chat).set({ visibility }).where(eq(chat.id, chatId));
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to update chat visibility by id"
+    );
+  }
+}
+
+export async function updateChatLastContextById({
+  chatId,
+  context,
+}: {
+  chatId: string;
+  // Store merged server-enriched usage object
+  context: AppUsage;
+}) {
+  try {
+    return await db
+      .update(chat)
+      .set({ lastContext: context })
+      .where(eq(chat.id, chatId));
+  } catch (error) {
+    console.warn("Failed to update lastContext for chat", chatId, error);
+    return;
+  }
+}
+
+export async function getMessageCountByUserId({
+  id,
+  differenceInHours,
+}: {
+  id: string;
+  differenceInHours: number;
+}) {
+  try {
+    const twentyFourHoursAgo = new Date(
+      Date.now() - differenceInHours * 60 * 60 * 1000
+    );
+
+    const [stats] = await db
+      .select({ count: count(message.id) })
+      .from(message)
+      .innerJoin(chat, eq(message.chatId, chat.id))
+      .where(
+        and(
+          eq(chat.userId, id),
+          gte(message.createdAt, twentyFourHoursAgo),
+          eq(message.role, "user")
+        )
+      )
+      .execute();
+
+    return stats?.count ?? 0;
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get message count by user id"
+    );
+  }
+}
+
+export async function createStreamId({
+  streamId,
+  chatId,
+}: {
+  streamId: string;
+  chatId: string;
+}) {
+  try {
+    await db
+      .insert(stream)
+      .values({ id: streamId, chatId, createdAt: new Date() });
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to create stream id"
+    );
+  }
+}
+
+export async function getStreamIdsByChatId({ chatId }: { chatId: string }) {
+  try {
+    const streamIds = await db
+      .select({ id: stream.id })
+      .from(stream)
+      .where(eq(stream.chatId, chatId))
+      .orderBy(asc(stream.createdAt))
+      .execute();
+
+    return streamIds.map(({ id }) => id);
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to get stream ids by chat id"
+    );
+  }
+}

--- a/packages/ai_frontend/lib/db/schema.ts
+++ b/packages/ai_frontend/lib/db/schema.ts
@@ -1,0 +1,173 @@
+import type { InferSelectModel } from "drizzle-orm";
+import {
+  boolean,
+  foreignKey,
+  json,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import type { AppUsage } from "../usage";
+
+export const user = pgTable("User", {
+  id: uuid("id").primaryKey().notNull().defaultRandom(),
+  email: varchar("email", { length: 64 }).notNull(),
+  password: varchar("password", { length: 64 }),
+});
+
+export type User = InferSelectModel<typeof user>;
+
+export const chat = pgTable("Chat", {
+  id: uuid("id").primaryKey().notNull().defaultRandom(),
+  createdAt: timestamp("createdAt").notNull(),
+  title: text("title").notNull(),
+  userId: uuid("userId")
+    .notNull()
+    .references(() => user.id),
+  visibility: varchar("visibility", { enum: ["public", "private"] })
+    .notNull()
+    .default("private"),
+  lastContext: jsonb("lastContext").$type<AppUsage | null>(),
+});
+
+export type Chat = InferSelectModel<typeof chat>;
+
+// DEPRECATED: The following schema is deprecated and will be removed in the future.
+// Read the migration guide at https://chat-sdk.dev/docs/migration-guides/message-parts
+export const messageDeprecated = pgTable("Message", {
+  id: uuid("id").primaryKey().notNull().defaultRandom(),
+  chatId: uuid("chatId")
+    .notNull()
+    .references(() => chat.id),
+  role: varchar("role").notNull(),
+  content: json("content").notNull(),
+  createdAt: timestamp("createdAt").notNull(),
+});
+
+export type MessageDeprecated = InferSelectModel<typeof messageDeprecated>;
+
+export const message = pgTable("Message_v2", {
+  id: uuid("id").primaryKey().notNull().defaultRandom(),
+  chatId: uuid("chatId")
+    .notNull()
+    .references(() => chat.id),
+  role: varchar("role").notNull(),
+  parts: json("parts").notNull(),
+  attachments: json("attachments").notNull(),
+  createdAt: timestamp("createdAt").notNull(),
+});
+
+export type DBMessage = InferSelectModel<typeof message>;
+
+// DEPRECATED: The following schema is deprecated and will be removed in the future.
+// Read the migration guide at https://chat-sdk.dev/docs/migration-guides/message-parts
+export const voteDeprecated = pgTable(
+  "Vote",
+  {
+    chatId: uuid("chatId")
+      .notNull()
+      .references(() => chat.id),
+    messageId: uuid("messageId")
+      .notNull()
+      .references(() => messageDeprecated.id),
+    isUpvoted: boolean("isUpvoted").notNull(),
+  },
+  (table) => {
+    return {
+      pk: primaryKey({ columns: [table.chatId, table.messageId] }),
+    };
+  }
+);
+
+export type VoteDeprecated = InferSelectModel<typeof voteDeprecated>;
+
+export const vote = pgTable(
+  "Vote_v2",
+  {
+    chatId: uuid("chatId")
+      .notNull()
+      .references(() => chat.id),
+    messageId: uuid("messageId")
+      .notNull()
+      .references(() => message.id),
+    isUpvoted: boolean("isUpvoted").notNull(),
+  },
+  (table) => {
+    return {
+      pk: primaryKey({ columns: [table.chatId, table.messageId] }),
+    };
+  }
+);
+
+export type Vote = InferSelectModel<typeof vote>;
+
+export const document = pgTable(
+  "Document",
+  {
+    id: uuid("id").notNull().defaultRandom(),
+    createdAt: timestamp("createdAt").notNull(),
+    title: text("title").notNull(),
+    content: text("content"),
+    kind: varchar("text", { enum: ["text", "code", "image", "sheet"] })
+      .notNull()
+      .default("text"),
+    userId: uuid("userId")
+      .notNull()
+      .references(() => user.id),
+  },
+  (table) => {
+    return {
+      pk: primaryKey({ columns: [table.id, table.createdAt] }),
+    };
+  }
+);
+
+export type Document = InferSelectModel<typeof document>;
+
+export const suggestion = pgTable(
+  "Suggestion",
+  {
+    id: uuid("id").notNull().defaultRandom(),
+    documentId: uuid("documentId").notNull(),
+    documentCreatedAt: timestamp("documentCreatedAt").notNull(),
+    originalText: text("originalText").notNull(),
+    suggestedText: text("suggestedText").notNull(),
+    description: text("description"),
+    isResolved: boolean("isResolved").notNull().default(false),
+    userId: uuid("userId")
+      .notNull()
+      .references(() => user.id),
+    createdAt: timestamp("createdAt").notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.id] }),
+    documentRef: foreignKey({
+      columns: [table.documentId, table.documentCreatedAt],
+      foreignColumns: [document.id, document.createdAt],
+    }),
+  })
+);
+
+export type Suggestion = InferSelectModel<typeof suggestion>;
+
+export const stream = pgTable(
+  "Stream",
+  {
+    id: uuid("id").notNull().defaultRandom(),
+    chatId: uuid("chatId").notNull(),
+    createdAt: timestamp("createdAt").notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.id] }),
+    chatRef: foreignKey({
+      columns: [table.chatId],
+      foreignColumns: [chat.id],
+    }),
+  })
+);
+
+export type Stream = InferSelectModel<typeof stream>;

--- a/packages/ai_frontend/lib/db/utils.ts
+++ b/packages/ai_frontend/lib/db/utils.ts
@@ -1,0 +1,16 @@
+import { generateId } from "ai";
+import { genSaltSync, hashSync } from "bcrypt-ts";
+
+export function generateHashedPassword(password: string) {
+  const salt = genSaltSync(10);
+  const hash = hashSync(password, salt);
+
+  return hash;
+}
+
+export function generateDummyPassword() {
+  const password = generateId();
+  const hashedPassword = generateHashedPassword(password);
+
+  return hashedPassword;
+}

--- a/packages/ai_frontend/lib/db/utils.ts
+++ b/packages/ai_frontend/lib/db/utils.ts
@@ -3,14 +3,10 @@ import { genSaltSync, hashSync } from "bcrypt-ts";
 
 export function generateHashedPassword(password: string) {
   const salt = genSaltSync(10);
-  const hash = hashSync(password, salt);
-
-  return hash;
+  return hashSync(password, salt);
 }
 
 export function generateDummyPassword() {
   const password = generateId();
-  const hashedPassword = generateHashedPassword(password);
-
-  return hashedPassword;
+  return generateHashedPassword(password);
 }

--- a/packages/ai_frontend/lib/editor/config.ts
+++ b/packages/ai_frontend/lib/editor/config.ts
@@ -1,0 +1,49 @@
+import { textblockTypeInputRule } from "prosemirror-inputrules";
+import { Schema } from "prosemirror-model";
+import { schema } from "prosemirror-schema-basic";
+import { addListNodes } from "prosemirror-schema-list";
+import type { Transaction } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+import type { MutableRefObject } from "react";
+
+import { buildContentFromDocument } from "./functions";
+
+export const documentSchema = new Schema({
+  nodes: addListNodes(schema.spec.nodes, "paragraph block*", "block"),
+  marks: schema.spec.marks,
+});
+
+export function headingRule(level: number) {
+  return textblockTypeInputRule(
+    new RegExp(`^(#{1,${level}})\\s$`),
+    documentSchema.nodes.heading,
+    () => ({ level })
+  );
+}
+
+export const handleTransaction = ({
+  transaction,
+  editorRef,
+  onSaveContent,
+}: {
+  transaction: Transaction;
+  editorRef: MutableRefObject<EditorView | null>;
+  onSaveContent: (updatedContent: string, debounce: boolean) => void;
+}) => {
+  if (!editorRef || !editorRef.current) {
+    return;
+  }
+
+  const newState = editorRef.current.state.apply(transaction);
+  editorRef.current.updateState(newState);
+
+  if (transaction.docChanged && !transaction.getMeta("no-save")) {
+    const updatedContent = buildContentFromDocument(newState.doc);
+
+    if (transaction.getMeta("no-debounce")) {
+      onSaveContent(updatedContent, false);
+    } else {
+      onSaveContent(updatedContent, true);
+    }
+  }
+};

--- a/packages/ai_frontend/lib/editor/diff.js
+++ b/packages/ai_frontend/lib/editor/diff.js
@@ -1,0 +1,475 @@
+// Modified from https://github.com/hamflx/prosemirror-diff/blob/master/src/diff.js
+
+import { diff_match_patch } from "diff-match-patch";
+import { Fragment, Node } from "prosemirror-model";
+
+export const DiffType = {
+  Unchanged: 0,
+  Deleted: -1,
+  Inserted: 1,
+};
+
+export const patchDocumentNode = (schema, oldNode, newNode) => {
+  assertNodeTypeEqual(oldNode, newNode);
+
+  const finalLeftChildren = [];
+  const finalRightChildren = [];
+
+  const oldChildren = normalizeNodeContent(oldNode);
+  const newChildren = normalizeNodeContent(newNode);
+  const oldChildLen = oldChildren.length;
+  const newChildLen = newChildren.length;
+  const minChildLen = Math.min(oldChildLen, newChildLen);
+
+  let left = 0;
+  let right = 0;
+
+  for (; left < minChildLen; left++) {
+    const oldChild = oldChildren[left];
+    const newChild = newChildren[left];
+    if (!isNodeEqual(oldChild, newChild)) {
+      break;
+    }
+    finalLeftChildren.push(...ensureArray(oldChild));
+  }
+
+  for (; right + left + 1 < minChildLen; right++) {
+    const oldChild = oldChildren[oldChildLen - right - 1];
+    const newChild = newChildren[newChildLen - right - 1];
+    if (!isNodeEqual(oldChild, newChild)) {
+      break;
+    }
+    finalRightChildren.unshift(...ensureArray(oldChild));
+  }
+
+  const diffOldChildren = oldChildren.slice(left, oldChildLen - right);
+  const diffNewChildren = newChildren.slice(left, newChildLen - right);
+
+  if (diffOldChildren.length && diffNewChildren.length) {
+    const matchedNodes = matchNodes(
+      schema,
+      diffOldChildren,
+      diffNewChildren
+    ).sort((a, b) => b.count - a.count);
+    const bestMatch = matchedNodes[0];
+    if (bestMatch) {
+      const { oldStartIndex, newStartIndex, oldEndIndex, newEndIndex } =
+        bestMatch;
+      const oldBeforeMatchChildren = diffOldChildren.slice(0, oldStartIndex);
+      const newBeforeMatchChildren = diffNewChildren.slice(0, newStartIndex);
+
+      finalLeftChildren.push(
+        ...patchRemainNodes(
+          schema,
+          oldBeforeMatchChildren,
+          newBeforeMatchChildren
+        )
+      );
+      finalLeftChildren.push(
+        ...diffOldChildren.slice(oldStartIndex, oldEndIndex)
+      );
+
+      const oldAfterMatchChildren = diffOldChildren.slice(oldEndIndex);
+      const newAfterMatchChildren = diffNewChildren.slice(newEndIndex);
+
+      finalRightChildren.unshift(
+        ...patchRemainNodes(
+          schema,
+          oldAfterMatchChildren,
+          newAfterMatchChildren
+        )
+      );
+    } else {
+      finalLeftChildren.push(
+        ...patchRemainNodes(schema, diffOldChildren, diffNewChildren)
+      );
+    }
+  } else {
+    finalLeftChildren.push(
+      ...patchRemainNodes(schema, diffOldChildren, diffNewChildren)
+    );
+  }
+
+  return createNewNode(oldNode, [...finalLeftChildren, ...finalRightChildren]);
+};
+
+const matchNodes = (_schema, oldChildren, newChildren) => {
+  const matches = [];
+  for (
+    let oldStartIndex = 0;
+    oldStartIndex < oldChildren.length;
+    oldStartIndex++
+  ) {
+    const oldStartNode = oldChildren[oldStartIndex];
+    const newStartIndex = findMatchNode(newChildren, oldStartNode);
+
+    if (newStartIndex !== -1) {
+      let oldEndIndex = oldStartIndex + 1;
+      let newEndIndex = newStartIndex + 1;
+      for (
+        ;
+        oldEndIndex < oldChildren.length && newEndIndex < newChildren.length;
+        oldEndIndex++, newEndIndex++
+      ) {
+        const oldEndNode = oldChildren[oldEndIndex];
+        if (!isNodeEqual(newChildren[newEndIndex], oldEndNode)) {
+          break;
+        }
+      }
+      matches.push({
+        oldStartIndex,
+        newStartIndex,
+        oldEndIndex,
+        newEndIndex,
+        count: newEndIndex - newStartIndex,
+      });
+    }
+  }
+  return matches;
+};
+
+const findMatchNode = (children, node, startIndex = 0) => {
+  for (let i = startIndex; i < children.length; i++) {
+    if (isNodeEqual(children[i], node)) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+const patchRemainNodes = (schema, oldChildren, newChildren) => {
+  const finalLeftChildren = [];
+  const finalRightChildren = [];
+  const oldChildLen = oldChildren.length;
+  const newChildLen = newChildren.length;
+  let left = 0;
+  let right = 0;
+  while (oldChildLen - left - right > 0 && newChildLen - left - right > 0) {
+    const leftOldNode = oldChildren[left];
+    const leftNewNode = newChildren[left];
+    const rightOldNode = oldChildren[oldChildLen - right - 1];
+    const rightNewNode = newChildren[newChildLen - right - 1];
+    let updateLeft =
+      !isTextNode(leftOldNode) && matchNodeType(leftOldNode, leftNewNode);
+    let updateRight =
+      !isTextNode(rightOldNode) && matchNodeType(rightOldNode, rightNewNode);
+    if (Array.isArray(leftOldNode) && Array.isArray(leftNewNode)) {
+      finalLeftChildren.push(
+        ...patchTextNodes(schema, leftOldNode, leftNewNode)
+      );
+      left += 1;
+      continue;
+    }
+
+    if (updateLeft && updateRight) {
+      const equalityLeft = computeChildEqualityFactor(leftOldNode, leftNewNode);
+      const equalityRight = computeChildEqualityFactor(
+        rightOldNode,
+        rightNewNode
+      );
+      if (equalityLeft < equalityRight) {
+        updateLeft = false;
+      } else {
+        updateRight = false;
+      }
+    }
+    if (updateLeft) {
+      finalLeftChildren.push(
+        patchDocumentNode(schema, leftOldNode, leftNewNode)
+      );
+      left += 1;
+    } else if (updateRight) {
+      finalRightChildren.unshift(
+        patchDocumentNode(schema, rightOldNode, rightNewNode)
+      );
+      right += 1;
+    } else {
+      // Delete and insert
+      finalLeftChildren.push(
+        createDiffNode(schema, leftOldNode, DiffType.Deleted)
+      );
+      finalLeftChildren.push(
+        createDiffNode(schema, leftNewNode, DiffType.Inserted)
+      );
+      left += 1;
+    }
+  }
+
+  const deleteNodeLen = oldChildLen - left - right;
+  const insertNodeLen = newChildLen - left - right;
+  if (deleteNodeLen) {
+    finalLeftChildren.push(
+      ...oldChildren
+        .slice(left, left + deleteNodeLen)
+        .flat()
+        .map((node) => createDiffNode(schema, node, DiffType.Deleted))
+    );
+  }
+
+  if (insertNodeLen) {
+    finalRightChildren.unshift(
+      ...newChildren
+        .slice(left, left + insertNodeLen)
+        .flat()
+        .map((node) => createDiffNode(schema, node, DiffType.Inserted))
+    );
+  }
+
+  return [...finalLeftChildren, ...finalRightChildren];
+};
+
+// Updated function to perform sentence-level diffs
+export const patchTextNodes = (schema, oldNode, newNode) => {
+  const dmp = new diff_match_patch();
+
+  // Concatenate the text from the text nodes
+  const oldText = oldNode.map((n) => getNodeText(n)).join("");
+  const newText = newNode.map((n) => getNodeText(n)).join("");
+
+  // Tokenize the text into sentences
+  const oldSentences = tokenizeSentences(oldText);
+  const newSentences = tokenizeSentences(newText);
+
+  // Map sentences to unique characters
+  const { chars1, chars2, lineArray } = sentencesToChars(
+    oldSentences,
+    newSentences
+  );
+
+  // Perform the diff
+  let diffs = dmp.diff_main(chars1, chars2, false);
+
+  // Convert back to sentences
+  diffs = diffs.map(([type, text]) => {
+    const sentences = text
+      .split("")
+      .map((char) => lineArray[char.charCodeAt(0)]);
+    return [type, sentences];
+  });
+
+  // Map diffs to nodes
+  const res = diffs.flatMap(([type, sentences]) => {
+    return sentences.map((sentence) => {
+      const node = createTextNode(
+        schema,
+        sentence,
+        type !== DiffType.Unchanged ? [createDiffMark(schema, type)] : []
+      );
+      return node;
+    });
+  });
+
+  return res;
+};
+
+// Function to tokenize text into sentences
+const tokenizeSentences = (text) => {
+  return text.match(/[^.!?]+[.!?]*\s*/g) || [];
+};
+
+// Function to map sentences to unique characters
+const sentencesToChars = (oldSentences, newSentences) => {
+  const lineArray = [];
+  const lineHash = {};
+  let lineStart = 0;
+
+  const chars1 = oldSentences
+    .map((sentence) => {
+      const line = sentence;
+      if (line in lineHash) {
+        return String.fromCharCode(lineHash[line]);
+      }
+      lineHash[line] = lineStart;
+      lineArray[lineStart] = line;
+      lineStart++;
+      return String.fromCharCode(lineHash[line]);
+    })
+    .join("");
+
+  const chars2 = newSentences
+    .map((sentence) => {
+      const line = sentence;
+      if (line in lineHash) {
+        return String.fromCharCode(lineHash[line]);
+      }
+      lineHash[line] = lineStart;
+      lineArray[lineStart] = line;
+      lineStart++;
+      return String.fromCharCode(lineHash[line]);
+    })
+    .join("");
+
+  return { chars1, chars2, lineArray };
+};
+
+export const computeChildEqualityFactor = (_node1, _node2) => {
+  return 0;
+};
+
+export const assertNodeTypeEqual = (node1, node2) => {
+  if (getNodeProperty(node1, "type") !== getNodeProperty(node2, "type")) {
+    throw new Error(`node type not equal: ${node1.type} !== ${node2.type}`);
+  }
+};
+
+export const ensureArray = (value) => {
+  return Array.isArray(value) ? value : [value];
+};
+
+export const isNodeEqual = (node1, node2) => {
+  const isNode1Array = Array.isArray(node1);
+  const isNode2Array = Array.isArray(node2);
+  if (isNode1Array !== isNode2Array) {
+    return false;
+  }
+  if (isNode1Array) {
+    return (
+      node1.length === node2.length &&
+      node1.every((node, index) => isNodeEqual(node, node2[index]))
+    );
+  }
+
+  const type1 = getNodeProperty(node1, "type");
+  const type2 = getNodeProperty(node2, "type");
+  if (type1 !== type2) {
+    return false;
+  }
+  if (isTextNode(node1)) {
+    const text1 = getNodeProperty(node1, "text");
+    const text2 = getNodeProperty(node2, "text");
+    if (text1 !== text2) {
+      return false;
+    }
+  }
+  const attrs1 = getNodeAttributes(node1);
+  const attrs2 = getNodeAttributes(node2);
+  const attrs = [...new Set([...Object.keys(attrs1), ...Object.keys(attrs2)])];
+  for (const attr of attrs) {
+    if (attrs1[attr] !== attrs2[attr]) {
+      return false;
+    }
+  }
+  const marks1 = getNodeMarks(node1);
+  const marks2 = getNodeMarks(node2);
+  if (marks1.length !== marks2.length) {
+    return false;
+  }
+  for (let i = 0; i < marks1.length; i++) {
+    if (!isNodeEqual(marks1[i], marks2[i])) {
+      return false;
+    }
+  }
+  const children1 = getNodeChildren(node1);
+  const children2 = getNodeChildren(node2);
+  if (children1.length !== children2.length) {
+    return false;
+  }
+  for (let i = 0; i < children1.length; i++) {
+    if (!isNodeEqual(children1[i], children2[i])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const normalizeNodeContent = (node) => {
+  const content = getNodeChildren(node) ?? [];
+  const res = [];
+  for (let i = 0; i < content.length; i++) {
+    const child = content[i];
+    if (isTextNode(child)) {
+      const textNodes = [];
+      for (
+        let textNode = content[i];
+        i < content.length && isTextNode(textNode);
+        textNode = content[++i]
+      ) {
+        textNodes.push(textNode);
+      }
+      i--;
+      res.push(textNodes);
+    } else {
+      res.push(child);
+    }
+  }
+  return res;
+};
+
+export const getNodeProperty = (node, property) => {
+  if (property === "type") {
+    return node.type?.name;
+  }
+  return node[property];
+};
+
+export const getNodeAttribute = (node, attribute) =>
+  node.attrs ? node.attrs[attribute] : undefined;
+
+export const getNodeAttributes = (node) => (node.attrs ? node.attrs : {});
+
+export const getNodeMarks = (node) => node.marks ?? [];
+
+export const getNodeChildren = (node) => node.content?.content ?? [];
+
+export const getNodeText = (node) => node.text;
+
+export const isTextNode = (node) => node.type?.name === "text";
+
+export const matchNodeType = (node1, node2) =>
+  node1.type?.name === node2.type?.name ||
+  (Array.isArray(node1) && Array.isArray(node2));
+
+export const createNewNode = (oldNode, children) => {
+  if (!oldNode.type) {
+    throw new Error("oldNode.type is undefined");
+  }
+  return new Node(
+    oldNode.type,
+    oldNode.attrs,
+    Fragment.fromArray(children),
+    oldNode.marks
+  );
+};
+
+export const createDiffNode = (schema, node, type) => {
+  return mapDocumentNode(node, (currentNode) => {
+    if (isTextNode(currentNode)) {
+      return createTextNode(schema, getNodeText(currentNode), [
+        ...(currentNode.marks || []),
+        createDiffMark(schema, type),
+      ]);
+    }
+    return currentNode;
+  });
+};
+
+function mapDocumentNode(node, mapper) {
+  const copy = node.copy(
+    Fragment.from(
+      node.content.content
+        .map((currentNode) => mapDocumentNode(currentNode, mapper))
+        .filter((n) => n)
+    )
+  );
+  return mapper(copy) || copy;
+}
+
+export const createDiffMark = (schema, type) => {
+  if (type === DiffType.Inserted) {
+    return schema.mark("diffMark", { type });
+  }
+  if (type === DiffType.Deleted) {
+    return schema.mark("diffMark", { type });
+  }
+  throw new Error("type is not valid");
+};
+
+export const createTextNode = (schema, content, marks = []) => {
+  return schema.text(content, marks);
+};
+
+export const diffEditor = (schema, oldDoc, newDoc) => {
+  const oldNode = Node.fromJSON(schema, oldDoc);
+  const newNode = Node.fromJSON(schema, newDoc);
+  return patchDocumentNode(schema, oldNode, newNode);
+};

--- a/packages/ai_frontend/lib/editor/diff.js
+++ b/packages/ai_frontend/lib/editor/diff.js
@@ -248,18 +248,15 @@ export const patchTextNodes = (schema, oldNode, newNode) => {
   });
 
   // Map diffs to nodes
-  const res = diffs.flatMap(([type, sentences]) => {
-    return sentences.map((sentence) => {
-      const node = createTextNode(
+  return diffs.flatMap(([type, sentences]) => {
+    return sentences.map((sentence) =>
+      createTextNode(
         schema,
         sentence,
         type !== DiffType.Unchanged ? [createDiffMark(schema, type)] : []
-      );
-      return node;
-    });
+      )
+    );
   });
-
-  return res;
 };
 
 // Function to tokenize text into sentences
@@ -302,8 +299,89 @@ const sentencesToChars = (oldSentences, newSentences) => {
   return { chars1, chars2, lineArray };
 };
 
-export const computeChildEqualityFactor = (_node1, _node2) => {
-  return 0;
+export const computeChildEqualityFactor = (node1, node2) => {
+  if (!node1 || !node2) {
+    return 0;
+  }
+
+  if (!matchNodeType(node1, node2)) {
+    return 0;
+  }
+
+  const factors = [];
+
+  if (isTextNode(node1) && isTextNode(node2)) {
+    const text1 = getNodeText(node1) ?? "";
+    const text2 = getNodeText(node2) ?? "";
+
+    if (text1 === text2) {
+      factors.push(1);
+    } else {
+      const dmp = new diff_match_patch();
+      const diffs = dmp.diff_main(text1, text2);
+      const unchangedLength = diffs
+        .filter(([type]) => type === DiffType.Unchanged)
+        .reduce((sum, [, value]) => sum + value.length, 0);
+      const maxLength = Math.max(text1.length, text2.length);
+      factors.push(maxLength === 0 ? 1 : unchangedLength / maxLength);
+    }
+  }
+
+  const attrs1 = getNodeAttributes(node1);
+  const attrs2 = getNodeAttributes(node2);
+  const attributeKeys = new Set([
+    ...Object.keys(attrs1),
+    ...Object.keys(attrs2),
+  ]);
+  if (attributeKeys.size > 0) {
+    let matches = 0;
+    attributeKeys.forEach((key) => {
+      if (attrs1[key] === attrs2[key]) {
+        matches += 1;
+      }
+    });
+    factors.push(matches / attributeKeys.size);
+  }
+
+  const marks1 = getNodeMarks(node1);
+  const marks2 = getNodeMarks(node2);
+  if (marks1.length || marks2.length) {
+    const maxLength = Math.max(marks1.length, marks2.length);
+    let matches = 0;
+    for (let index = 0; index < maxLength; index++) {
+      if (marks1[index] && marks2[index] && isNodeEqual(marks1[index], marks2[index])) {
+        matches += 1;
+      }
+    }
+    factors.push(maxLength === 0 ? 1 : matches / maxLength);
+  }
+
+  const children1 = getNodeChildren(node1);
+  const children2 = getNodeChildren(node2);
+  if (children1.length || children2.length) {
+    const maxLength = Math.max(children1.length, children2.length);
+    let matches = 0;
+    for (let index = 0; index < maxLength; index++) {
+      if (
+        children1[index] &&
+        children2[index] &&
+        isNodeEqual(children1[index], children2[index])
+      ) {
+        matches += 1;
+      }
+    }
+    factors.push(maxLength === 0 ? 1 : matches / maxLength);
+  }
+
+  if (factors.length === 0) {
+    return 1;
+  }
+
+  return (
+    factors.reduce((sum, value) => {
+      return sum + value;
+    }, 0) / factors.length
+  );
 };
 
 export const assertNodeTypeEqual = (node1, node2) => {
@@ -405,7 +483,7 @@ export const getNodeProperty = (node, property) => {
 export const getNodeAttribute = (node, attribute) =>
   node.attrs ? node.attrs[attribute] : undefined;
 
-export const getNodeAttributes = (node) => (node.attrs ? node.attrs : {});
+export const getNodeAttributes = (node) => node.attrs || {};
 
 export const getNodeMarks = (node) => node.marks ?? [];
 

--- a/packages/ai_frontend/lib/editor/functions.tsx
+++ b/packages/ai_frontend/lib/editor/functions.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { defaultMarkdownSerializer } from "prosemirror-markdown";
+import { DOMParser, type Node } from "prosemirror-model";
+import { Decoration, DecorationSet, type EditorView } from "prosemirror-view";
+import { renderToString } from "react-dom/server";
+
+import { Response } from "@/components/elements/response";
+
+import { documentSchema } from "./config";
+import { createSuggestionWidget, type UISuggestion } from "./suggestions";
+
+export const buildDocumentFromContent = (content: string) => {
+  const parser = DOMParser.fromSchema(documentSchema);
+  const stringFromMarkdown = renderToString(<Response>{content}</Response>);
+  const tempContainer = document.createElement("div");
+  tempContainer.innerHTML = stringFromMarkdown;
+  return parser.parse(tempContainer);
+};
+
+export const buildContentFromDocument = (document: Node) => {
+  return defaultMarkdownSerializer.serialize(document);
+};
+
+export const createDecorations = (
+  suggestions: UISuggestion[],
+  view: EditorView
+) => {
+  const decorations: Decoration[] = [];
+
+  for (const suggestion of suggestions) {
+    decorations.push(
+      Decoration.inline(
+        suggestion.selectionStart,
+        suggestion.selectionEnd,
+        {
+          class: "suggestion-highlight",
+        },
+        {
+          suggestionId: suggestion.id,
+          type: "highlight",
+        }
+      )
+    );
+
+    decorations.push(
+      Decoration.widget(
+        suggestion.selectionStart,
+        (currentView) => {
+          const { dom } = createSuggestionWidget(suggestion, currentView);
+          return dom;
+        },
+        {
+          suggestionId: suggestion.id,
+          type: "widget",
+        }
+      )
+    );
+  }
+
+  return DecorationSet.create(view.state.doc, decorations);
+};

--- a/packages/ai_frontend/lib/editor/functions.tsx
+++ b/packages/ai_frontend/lib/editor/functions.tsx
@@ -13,9 +13,18 @@ import { createSuggestionWidget, type UISuggestion } from "./suggestions";
 export const buildDocumentFromContent = (content: string) => {
   const parser = DOMParser.fromSchema(documentSchema);
   const stringFromMarkdown = renderToString(<Response>{content}</Response>);
-  const tempContainer = document.createElement("div");
-  tempContainer.innerHTML = stringFromMarkdown;
-  return parser.parse(tempContainer);
+  const HtmlParser =
+    typeof window === "undefined" ? globalThis.DOMParser : window.DOMParser;
+
+  if (!HtmlParser) {
+    throw new Error("DOMParser is not available in the current environment");
+  }
+
+  const parsedDocument = new HtmlParser().parseFromString(
+    stringFromMarkdown,
+    "text/html"
+  );
+  return parser.parse(parsedDocument.body);
 };
 
 export const buildContentFromDocument = (document: Node) => {

--- a/packages/ai_frontend/lib/editor/react-renderer.tsx
+++ b/packages/ai_frontend/lib/editor/react-renderer.tsx
@@ -1,0 +1,13 @@
+import { createRoot } from "react-dom/client";
+
+// biome-ignore lint/complexity/noStaticOnlyClass: "Needs to be static"
+export class ReactRenderer {
+  static render(component: React.ReactElement, dom: HTMLElement) {
+    const root = createRoot(dom);
+    root.render(component);
+
+    return {
+      destroy: () => root.unmount(),
+    };
+  }
+}

--- a/packages/ai_frontend/lib/editor/suggestions.tsx
+++ b/packages/ai_frontend/lib/editor/suggestions.tsx
@@ -1,0 +1,158 @@
+import type { Node } from "prosemirror-model";
+import { Plugin, PluginKey } from "prosemirror-state";
+import {
+  type Decoration,
+  DecorationSet,
+  type EditorView,
+} from "prosemirror-view";
+import { createRoot } from "react-dom/client";
+import type { ArtifactKind } from "@/components/artifact";
+import { Suggestion as PreviewSuggestion } from "@/components/suggestion";
+import type { Suggestion } from "@/lib/db/schema";
+
+export interface UISuggestion extends Suggestion {
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+type Position = {
+  start: number;
+  end: number;
+};
+
+function findPositionsInDoc(doc: Node, searchText: string): Position | null {
+  let positions: { start: number; end: number } | null = null;
+
+  doc.nodesBetween(0, doc.content.size, (node, pos) => {
+    if (node.isText && node.text) {
+      const index = node.text.indexOf(searchText);
+
+      if (index !== -1) {
+        positions = {
+          start: pos + index,
+          end: pos + index + searchText.length,
+        };
+
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  return positions;
+}
+
+export function projectWithPositions(
+  doc: Node,
+  suggestions: Suggestion[]
+): UISuggestion[] {
+  return suggestions.map((suggestion) => {
+    const positions = findPositionsInDoc(doc, suggestion.originalText);
+
+    if (!positions) {
+      return {
+        ...suggestion,
+        selectionStart: 0,
+        selectionEnd: 0,
+      };
+    }
+
+    return {
+      ...suggestion,
+      selectionStart: positions.start,
+      selectionEnd: positions.end,
+    };
+  });
+}
+
+export function createSuggestionWidget(
+  suggestion: UISuggestion,
+  view: EditorView,
+  artifactKind: ArtifactKind = "text"
+): { dom: HTMLElement; destroy: () => void } {
+  const dom = document.createElement("span");
+  const root = createRoot(dom);
+
+  dom.addEventListener("mousedown", (event) => {
+    event.preventDefault();
+    view.dom.blur();
+  });
+
+  const onApply = () => {
+    const { state, dispatch } = view;
+
+    const decorationTransaction = state.tr;
+    const currentState = suggestionsPluginKey.getState(state);
+    const currentDecorations = currentState?.decorations;
+
+    if (currentDecorations) {
+      const newDecorations = DecorationSet.create(
+        state.doc,
+        currentDecorations.find().filter((decoration: Decoration) => {
+          return decoration.spec.suggestionId !== suggestion.id;
+        })
+      );
+
+      decorationTransaction.setMeta(suggestionsPluginKey, {
+        decorations: newDecorations,
+        selected: null,
+      });
+      dispatch(decorationTransaction);
+    }
+
+    const textTransaction = view.state.tr.replaceWith(
+      suggestion.selectionStart,
+      suggestion.selectionEnd,
+      state.schema.text(suggestion.suggestedText)
+    );
+
+    textTransaction.setMeta("no-debounce", true);
+
+    dispatch(textTransaction);
+  };
+
+  root.render(
+    <PreviewSuggestion
+      artifactKind={artifactKind}
+      onApply={onApply}
+      suggestion={suggestion}
+    />
+  );
+
+  return {
+    dom,
+    destroy: () => {
+      // Wrapping unmount in setTimeout to avoid synchronous unmounting during render
+      setTimeout(() => {
+        root.unmount();
+      }, 0);
+    },
+  };
+}
+
+export const suggestionsPluginKey = new PluginKey("suggestions");
+export const suggestionsPlugin = new Plugin({
+  key: suggestionsPluginKey,
+  state: {
+    init() {
+      return { decorations: DecorationSet.empty, selected: null };
+    },
+    apply(tr, state) {
+      const newDecorations = tr.getMeta(suggestionsPluginKey);
+      if (newDecorations) {
+        return newDecorations;
+      }
+
+      return {
+        decorations: state.decorations.map(tr.mapping, tr.doc),
+        selected: state.selected,
+      };
+    },
+  },
+  props: {
+    decorations(state) {
+      return this.getState(state)?.decorations ?? DecorationSet.empty;
+    },
+  },
+});

--- a/packages/ai_frontend/lib/errors.ts
+++ b/packages/ai_frontend/lib/errors.ts
@@ -1,0 +1,137 @@
+export type ErrorType =
+  | "bad_request"
+  | "unauthorized"
+  | "forbidden"
+  | "not_found"
+  | "rate_limit"
+  | "offline";
+
+export type Surface =
+  | "chat"
+  | "auth"
+  | "api"
+  | "stream"
+  | "database"
+  | "history"
+  | "vote"
+  | "document"
+  | "suggestions"
+  | "activate_gateway";
+
+export type ErrorCode = `${ErrorType}:${Surface}`;
+
+export type ErrorVisibility = "response" | "log" | "none";
+
+export const visibilityBySurface: Record<Surface, ErrorVisibility> = {
+  database: "log",
+  chat: "response",
+  auth: "response",
+  stream: "response",
+  api: "response",
+  history: "response",
+  vote: "response",
+  document: "response",
+  suggestions: "response",
+  activate_gateway: "response",
+};
+
+export class ChatSDKError extends Error {
+  type: ErrorType;
+  surface: Surface;
+  statusCode: number;
+
+  constructor(errorCode: ErrorCode, cause?: string) {
+    super();
+
+    const [type, surface] = errorCode.split(":");
+
+    this.type = type as ErrorType;
+    this.cause = cause;
+    this.surface = surface as Surface;
+    this.message = getMessageByErrorCode(errorCode);
+    this.statusCode = getStatusCodeByType(this.type);
+  }
+
+  toResponse() {
+    const code: ErrorCode = `${this.type}:${this.surface}`;
+    const visibility = visibilityBySurface[this.surface];
+
+    const { message, cause, statusCode } = this;
+
+    if (visibility === "log") {
+      console.error({
+        code,
+        message,
+        cause,
+      });
+
+      return Response.json(
+        { code: "", message: "Something went wrong. Please try again later." },
+        { status: statusCode }
+      );
+    }
+
+    return Response.json({ code, message, cause }, { status: statusCode });
+  }
+}
+
+export function getMessageByErrorCode(errorCode: ErrorCode): string {
+  if (errorCode.includes("database")) {
+    return "An error occurred while executing a database query.";
+  }
+
+  switch (errorCode) {
+    case "bad_request:api":
+      return "The request couldn't be processed. Please check your input and try again.";
+
+    case "bad_request:activate_gateway":
+      return "AI Gateway requires a valid credit card on file to service requests. Please visit https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%3Fmodal%3Dadd-credit-card to add a card and unlock your free credits.";
+
+    case "unauthorized:auth":
+      return "You need to sign in before continuing.";
+    case "forbidden:auth":
+      return "Your account does not have access to this feature.";
+
+    case "rate_limit:chat":
+      return "You have exceeded your maximum number of messages for the day. Please try again later.";
+    case "not_found:chat":
+      return "The requested chat was not found. Please check the chat ID and try again.";
+    case "forbidden:chat":
+      return "This chat belongs to another user. Please check the chat ID and try again.";
+    case "unauthorized:chat":
+      return "You need to sign in to view this chat. Please sign in and try again.";
+    case "offline:chat":
+      return "We're having trouble sending your message. Please check your internet connection and try again.";
+
+    case "not_found:document":
+      return "The requested document was not found. Please check the document ID and try again.";
+    case "forbidden:document":
+      return "This document belongs to another user. Please check the document ID and try again.";
+    case "unauthorized:document":
+      return "You need to sign in to view this document. Please sign in and try again.";
+    case "bad_request:document":
+      return "The request to create or update the document was invalid. Please check your input and try again.";
+
+    default:
+      return "Something went wrong. Please try again later.";
+  }
+}
+
+function getStatusCodeByType(type: ErrorType) {
+  switch (type) {
+    case "bad_request":
+      return 400;
+    case "unauthorized":
+      return 401;
+    case "forbidden":
+      return 403;
+    case "not_found":
+      return 404;
+    case "rate_limit":
+      return 429;
+    case "offline":
+      return 503;
+    default:
+      return 500;
+  }
+}

--- a/packages/ai_frontend/lib/types.ts
+++ b/packages/ai_frontend/lib/types.ts
@@ -1,0 +1,58 @@
+import type { InferUITool, UIMessage } from "ai";
+import { z } from "zod";
+import type { ArtifactKind } from "@/components/artifact";
+import type { createDocument } from "./ai/tools/create-document";
+import type { getWeather } from "./ai/tools/get-weather";
+import type { requestSuggestions } from "./ai/tools/request-suggestions";
+import type { updateDocument } from "./ai/tools/update-document";
+import type { Suggestion } from "./db/schema";
+import type { AppUsage } from "./usage";
+
+export type DataPart = { type: "append-message"; message: string };
+
+export const messageMetadataSchema = z.object({
+  createdAt: z.string(),
+});
+
+export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
+
+type weatherTool = InferUITool<typeof getWeather>;
+type createDocumentTool = InferUITool<ReturnType<typeof createDocument>>;
+type updateDocumentTool = InferUITool<ReturnType<typeof updateDocument>>;
+type requestSuggestionsTool = InferUITool<
+  ReturnType<typeof requestSuggestions>
+>;
+
+export type ChatTools = {
+  getWeather: weatherTool;
+  createDocument: createDocumentTool;
+  updateDocument: updateDocumentTool;
+  requestSuggestions: requestSuggestionsTool;
+};
+
+export type CustomUIDataTypes = {
+  textDelta: string;
+  imageDelta: string;
+  sheetDelta: string;
+  codeDelta: string;
+  suggestion: Suggestion;
+  appendMessage: string;
+  id: string;
+  title: string;
+  kind: ArtifactKind;
+  clear: null;
+  finish: null;
+  usage: AppUsage;
+};
+
+export type ChatMessage = UIMessage<
+  MessageMetadata,
+  CustomUIDataTypes,
+  ChatTools
+>;
+
+export type Attachment = {
+  name: string;
+  url: string;
+  contentType: string;
+};

--- a/packages/ai_frontend/lib/usage.ts
+++ b/packages/ai_frontend/lib/usage.ts
@@ -1,0 +1,5 @@
+import type { LanguageModelUsage } from "ai";
+import type { UsageData } from "tokenlens/helpers";
+
+// Server-merged usage: base usage + TokenLens summary + optional modelId
+export type AppUsage = LanguageModelUsage & UsageData & { modelId?: string };

--- a/packages/ai_frontend/lib/utils.ts
+++ b/packages/ai_frontend/lib/utils.ts
@@ -1,0 +1,116 @@
+import type {
+  CoreAssistantMessage,
+  CoreToolMessage,
+  UIMessage,
+  UIMessagePart,
+} from 'ai';
+import { type ClassValue, clsx } from 'clsx';
+import { formatISO } from 'date-fns';
+import { twMerge } from 'tailwind-merge';
+import type { DBMessage, Document } from '@/lib/db/schema';
+import { ChatSDKError, type ErrorCode } from './errors';
+import type { ChatMessage, ChatTools, CustomUIDataTypes } from './types';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export const fetcher = async (url: string) => {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const { code, cause } = await response.json();
+    throw new ChatSDKError(code as ErrorCode, cause);
+  }
+
+  return response.json();
+};
+
+export async function fetchWithErrorHandlers(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) {
+  try {
+    const response = await fetch(input, init);
+
+    if (!response.ok) {
+      const { code, cause } = await response.json();
+      throw new ChatSDKError(code as ErrorCode, cause);
+    }
+
+    return response;
+  } catch (error: unknown) {
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      throw new ChatSDKError('offline:chat');
+    }
+
+    throw error;
+  }
+}
+
+export function getLocalStorage(key: string) {
+  if (typeof window !== 'undefined') {
+    return JSON.parse(localStorage.getItem(key) || '[]');
+  }
+  return [];
+}
+
+export function generateUUID(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+type ResponseMessageWithoutId = CoreToolMessage | CoreAssistantMessage;
+type ResponseMessage = ResponseMessageWithoutId & { id: string };
+
+export function getMostRecentUserMessage(messages: UIMessage[]) {
+  const userMessages = messages.filter((message) => message.role === 'user');
+  return userMessages.at(-1);
+}
+
+export function getDocumentTimestampByIndex(
+  documents: Document[],
+  index: number,
+) {
+  if (!documents) { return new Date(); }
+  if (index > documents.length) { return new Date(); }
+
+  return documents[index].createdAt;
+}
+
+export function getTrailingMessageId({
+  messages,
+}: {
+  messages: ResponseMessage[];
+}): string | null {
+  const trailingMessage = messages.at(-1);
+
+  if (!trailingMessage) { return null; }
+
+  return trailingMessage.id;
+}
+
+export function sanitizeText(text: string) {
+  return text.replace('<has_function_call>', '');
+}
+
+export function convertToUIMessages(messages: DBMessage[]): ChatMessage[] {
+  return messages.map((message) => ({
+    id: message.id,
+    role: message.role as 'user' | 'assistant' | 'system',
+    parts: message.parts as UIMessagePart<CustomUIDataTypes, ChatTools>[],
+    metadata: {
+      createdAt: formatISO(message.createdAt),
+    },
+  }));
+}
+
+export function getTextFromMessage(message: ChatMessage): string {
+  return message.parts
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('');
+}

--- a/packages/ai_frontend/package.json
+++ b/packages/ai_frontend/package.json
@@ -18,10 +18,9 @@
     "test": "export PLAYWRIGHT=True && pnpm exec playwright test"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "^1.0.15",
+    "@ai-sdk/openai-compatible": "^1.0.19",
     "@ai-sdk/provider": "2.0.0",
     "@ai-sdk/react": "2.0.26",
-    "@ai-sdk/xai": "2.0.13",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-python": "^6.1.6",
     "@codemirror/state": "^6.5.0",

--- a/packages/ai_frontend/pnpm-lock.yaml
+++ b/packages/ai_frontend/pnpm-lock.yaml
@@ -8,18 +8,15 @@ importers:
 
   .:
     dependencies:
-      '@ai-sdk/gateway':
-        specifier: ^1.0.15
-        version: 1.0.15(zod@3.25.76)
+      '@ai-sdk/openai-compatible':
+        specifier: ^1.0.19
+        version: 1.0.19(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: 2.0.0
         version: 2.0.0
       '@ai-sdk/react':
         specifier: 2.0.26
         version: 2.0.26(react@19.0.0-rc-45804af1-20241021)(zod@3.25.76)
-      '@ai-sdk/xai':
-        specifier: 2.0.13
-        version: 2.0.13(zod@3.25.76)
       '@codemirror/lang-javascript':
         specifier: ^6.2.2
         version: 6.2.3
@@ -279,11 +276,17 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
-  '@ai-sdk/openai-compatible@1.0.13':
-    resolution: {integrity: sha512-g46fLVWKcVg1XOFzDLoJ0XuhtY5XxxBwMQ0FT/aHwCtg6WUvk3Elrd+MKmgfvhZAdIR7CpUTvgJAAipu4RW75w==}
+  '@ai-sdk/openai-compatible@1.0.19':
+    resolution: {integrity: sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.10':
+    resolution: {integrity: sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider-utils@3.0.7':
     resolution: {integrity: sha512-o3BS5/t8KnBL3ubP8k3w77AByOypLm+pkIL/DCw0qKkhDbvhCy+L3hRTGPikpdb8WHcylAeKsjgwOxhj4cqTUA==}
@@ -304,12 +307,6 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
-
-  '@ai-sdk/xai@2.0.13':
-    resolution: {integrity: sha512-nWOmAInQg8uGIJ08XBxKQ9vmFpgS+bulCKtNMatW5Q62sza+f/1vuVo7fBPbxGm5SWUOno6hjAKi3ipVpLcwRQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -4363,10 +4360,17 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.7(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai-compatible@1.0.13(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@1.0.19(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.7(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.10(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@3.0.10(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.5
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@3.0.7(zod@3.25.76)':
@@ -4388,13 +4392,6 @@ snapshots:
       swr: 2.3.3(react@19.0.0-rc-45804af1-20241021)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.25.76
-
-  '@ai-sdk/xai@2.0.13(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/openai-compatible': 1.0.13(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.7(zod@3.25.76)
       zod: 3.25.76
 
   '@alloc/quick-lru@5.2.0': {}


### PR DESCRIPTION
## Summary
- restore the `packages/ai_frontend/lib` source tree copied from the upstream template so database utilities, AI helpers, and editor logic are available during builds
- update the repository .gitignore to allow committing the frontend's lib directory while continuing to ignore Python virtual environment libraries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d784ada2608321a4aa3a8f1e059814

## Summary by Sourcery

Restore the missing ai_frontend library source tree under packages/ai_frontend/lib and update .gitignore to include the restored files while preserving Python venv ignores

New Features:
- Reintroduce database layer with queries, schema definitions, migration scripts, and utilities for users, chats, messages, votes, documents, suggestions, and streams
- Restore ProseMirror-based editor modules including diff computation, suggestion widgets, schema configuration, and React rendering
- Re-add AI tool integrations for document creation, updating, suggestion generation, weather fetching, prompts, and model provider configuration
- Reinstate shared utility modules for error handling, API fetching with error wrappers, UUID generation, CSS class merging, and message-to-UI conversion

Build:
- Update .gitignore to allow committing the ai_frontend lib directory while continuing to ignore Python virtual environment libraries

Tests:
- Add AI model mocks and unit tests for streaming and prompt handling in ai/models.test.ts