### PR TITLE
feat: stream tool call metadata in chat completions

### DIFF
--- a/packages/legal_tools/api_server.py
+++ b/packages/legal_tools/api_server.py
@@ -57,9 +57,16 @@ def _normalize_tool_calls(
     if not tool_calls or not isinstance(tool_calls, list):
         return None
 
+    import logging
+    logger = logging.getLogger(__name__)
+
     normalized: List[Dict[str, Any]] = []
     for index, call in enumerate(tool_calls):
         if not isinstance(call, dict):
+            logger.warning(
+                "Malformed tool call at index %d: expected dict, got %s (%r)",
+                index, type(call).__name__, call
+            )
             continue
         fn: Dict[str, Any] = {}
         raw_fn = call.get("function")

--- a/packages/legal_tools/api_server.py
+++ b/packages/legal_tools/api_server.py
@@ -242,8 +242,8 @@ class ChatHandler(BaseHTTPRequestHandler):
                 law_payload["checkpoint_id"] = checkpoint_id
             if tool_usage:
                 law_payload["tool_usage"] = tool_usage
-                if raw_tool_call_chunks:
-                    tool_usage.setdefault("tool_call_chunks", raw_tool_call_chunks)
+            if raw_tool_call_chunks:
+                law_payload["tool_call_chunks"] = raw_tool_call_chunks
 
             if stream:
                 self._stream_answer(

--- a/packages/legal_tools/api_server.py
+++ b/packages/legal_tools/api_server.py
@@ -75,9 +75,8 @@ def _normalize_tool_calls(
             arguments = ""
         else:
             arguments = str(raw_args)
-        call_id = call.get("id") or call.get("tool_call_id")
-        if not call_id:
-            call_id = f"call_{index:04d}"
+        call_id = call.get("id") or call.get("tool_call_id") or f"call_{index:04d}"
+
         normalized.append(
             {
                 "id": str(call_id),

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -178,7 +178,13 @@ class PostgresChatManager:
         role = self._normalize_role(message.get("role") or message.get("type"))
         content = self._coerce_content(message.get("content"))
         payload: Dict[str, Any] = {"role": role, "content": content}
-        for key in ("name", "tool_calls", "tool_call_id", "function_call"):
+        for key in (
+            "name",
+            "tool_calls",
+            "tool_call_chunks",
+            "tool_call_id",
+            "function_call",
+        ):
             if key in message:
                 payload[key] = message[key]
         if "metadata" in message:
@@ -191,6 +197,14 @@ class PostgresChatManager:
             role = self._normalize_role(getattr(message, "role", None) or message.type)
             content = self._coerce_content(getattr(message, "content", ""))
             data: Dict[str, Any] = {"role": role, "content": content}
+            if getattr(message, "name", None):
+                data["name"] = getattr(message, "name")
+            if getattr(message, "tool_calls", None):
+                data["tool_calls"] = getattr(message, "tool_calls")
+            if getattr(message, "tool_call_chunks", None):
+                data["tool_call_chunks"] = getattr(message, "tool_call_chunks")
+            if getattr(message, "tool_call_id", None):
+                data["tool_call_id"] = getattr(message, "tool_call_id")
             if extra := getattr(message, "additional_kwargs", None):
                 data["additional_kwargs"] = dict(extra)
             return data
@@ -203,6 +217,7 @@ class PostgresChatManager:
                 "metadata",
                 "name",
                 "tool_calls",
+                "tool_call_chunks",
                 "tool_call_id",
             ):
                 if key in message:

--- a/tests/test_multi_turn_chat_manager.py
+++ b/tests/test_multi_turn_chat_manager.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("langgraph")
+
+
+from packages.legal_tools import multi_turn_chat as mtc
+
+
+class DummyCheckpointer:
+    def __init__(self) -> None:
+        self.setup_called = False
+
+    def setup(self) -> None:
+        self.setup_called = True
+
+
+class DummyContextManager:
+    def __init__(self, checkpointer: DummyCheckpointer) -> None:
+        self.checkpointer = checkpointer
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self) -> DummyCheckpointer:
+        self.entered = True
+        return self.checkpointer
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.exited = True
+
+
+class DummyCompiledGraph:
+    def invoke(self, *_args, **_kwargs) -> None:
+        return None
+
+    def get_state(self, _cfg):
+        return None
+
+    def get_state_history(self, _cfg):
+        return []
+
+
+def test_postgres_chat_manager_sets_up_checkpointer(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_checkpointer = DummyCheckpointer()
+    ctx = DummyContextManager(dummy_checkpointer)
+
+    def fake_from_conn_string(cls, db_uri: str):  # type: ignore[override]
+        assert db_uri == "postgresql://example"
+        return ctx
+
+    monkeypatch.setattr(
+        mtc.PostgresSaver,
+        "from_conn_string",
+        classmethod(fake_from_conn_string),
+    )
+
+    created_graphs = []
+
+    class DummyStateGraph:
+        def __init__(self, _state):
+            created_graphs.append(self)
+
+        def add_node(self, *_args, **_kwargs) -> None:
+            return None
+
+        def add_edge(self, *_args, **_kwargs) -> None:
+            return None
+
+        def compile(self, *, checkpointer):
+            assert checkpointer is dummy_checkpointer
+            return DummyCompiledGraph()
+
+    monkeypatch.setattr(mtc, "StateGraph", DummyStateGraph)
+
+    class DummyModel:
+        def invoke(self, _messages):
+            return {"role": "assistant", "content": "ok"}
+
+    monkeypatch.setattr(mtc, "init_chat_model", lambda _model_id: DummyModel())
+
+    config = mtc.PostgresChatConfig(db_uri="postgresql://example")
+
+    manager = mtc.PostgresChatManager(config=config)
+
+    assert ctx.entered is True
+    assert dummy_checkpointer.setup_called is True
+    assert isinstance(manager._graph, DummyCompiledGraph)  # type: ignore[attr-defined]
+
+    manager.close()
+    assert ctx.exited is True
+    assert manager._checkpointer is None  # type: ignore[attr-defined]
+    assert manager._checkpointer_cm is None  # type: ignore[attr-defined]
+
+    # close twice to ensure idempotence
+    manager.close()

--- a/tests/test_streaming_tool_calls.py
+++ b/tests/test_streaming_tool_calls.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("langchain")
+
+from packages.legal_tools.api_server import _normalize_tool_calls
+from packages.legal_tools.multi_turn_chat import PostgresChatManager
+
+
+def _make_manager() -> PostgresChatManager:
+    return PostgresChatManager.__new__(PostgresChatManager)
+
+
+def test_normalize_tool_calls_converts_args_to_strings() -> None:
+    tool_calls = [
+        {"id": "call_1", "name": "multiply", "args": {"a": 3, "b": 12}},
+        {
+            "tool_call_id": "call_2",
+            "function": {"name": "add", "arguments": "{\"a\": 11}"},
+        },
+    ]
+
+    normalized = _normalize_tool_calls(tool_calls)
+
+    assert normalized == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "multiply", "arguments": "{\"a\": 3, \"b\": 12}"},
+        },
+        {
+            "id": "call_2",
+            "type": "function",
+            "function": {"name": "add", "arguments": "{\"a\": 11}"},
+        },
+    ]
+
+
+def test_prepare_incoming_message_preserves_tool_call_chunks() -> None:
+    manager = _make_manager()
+    message = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"name": "Multiply"}],
+        "tool_call_chunks": [{"index": 0, "args": "{\"a\": 1}"}],
+    }
+
+    prepared = manager._prepare_incoming_message(message)
+
+    assert prepared["tool_calls"] == message["tool_calls"]
+    assert prepared["tool_call_chunks"] == message["tool_call_chunks"]
+
+
+def test_message_to_dict_retains_tool_call_chunks() -> None:
+    manager = _make_manager()
+    message = {
+        "role": "assistant",
+        "content": "result",
+        "tool_calls": [{"name": "Add"}],
+        "tool_call_chunks": [{"index": 1, "args": "{\"b\": 2}"}],
+    }
+
+    as_dict = manager._message_to_dict(message)
+
+    assert as_dict["tool_calls"] == message["tool_calls"]
+    assert as_dict["tool_call_chunks"] == message["tool_call_chunks"]

--- a/tests/test_streaming_tool_calls.py
+++ b/tests/test_streaming_tool_calls.py
@@ -50,6 +50,11 @@ def test_prepare_incoming_message_preserves_tool_call_chunks() -> None:
 
     assert prepared["tool_calls"] == message["tool_calls"]
     assert prepared["tool_call_chunks"] == message["tool_call_chunks"]
+    assert prepared["role"] == message["role"]
+    assert prepared["content"] == message["content"]
+    # Ensure no unexpected fields are present or missing
+    expected_keys = set(message.keys())
+    assert set(prepared.keys()) == expected_keys
 
 
 def test_message_to_dict_retains_tool_call_chunks() -> None:


### PR DESCRIPTION
## Summary
- preserve `tool_call_chunks` fields when normalizing chat messages for Postgres-backed conversations
- convert LangChain tool call payloads into OpenAI-compatible structures and surface them in streaming/non-streaming responses
- cover the new helpers with focused unit tests guarding the serialization logic

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7d02d1bbc8321833cac816b2203fa

## Summary by Sourcery

Enable streaming and non-streaming chat completions to include structured tool call metadata by normalizing LangChain payloads and preserving tool_call_chunks in message processing

New Features:
- Stream tool call metadata (tool_calls and tool_call_chunks) in both streaming and non-streaming chat completions

Enhancements:
- Add _normalize_tool_calls helper to convert LangChain tool call payloads into OpenAI-compatible structures
- Preserve tool_call_chunks fields during message normalization and serialization in PostgresChatManager

Tests:
- Introduce unit tests for _normalize_tool_calls, _prepare_incoming_message, and _message_to_dict to validate tool call serialization and preservation