### PR TITLE
feat(chat): stream postgres chat responses

### DIFF
--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -178,7 +178,9 @@ class PostgresChatManager:
         def _content_from_chunk(chunk: AIMessageChunk) -> str:
             try:
                 return self._coerce_content(chunk.content)
-            except Exception:
+            except (AttributeError, TypeError) as exc:
+                import logging
+                logging.error("Error in _coerce_content: %s", exc, exc_info=True)
                 return str(chunk.content or "")
 
         def _emit_events() -> Iterator[Dict[str, Any]]:

--- a/packages/legal_tools/multi_turn_chat.py
+++ b/packages/legal_tools/multi_turn_chat.py
@@ -4,10 +4,15 @@ import os
 import uuid
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
 
 from langchain.chat_models import init_chat_model
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import (
+    AIMessageChunk,
+    BaseMessage,
+    message_chunk_to_message,
+    messages_from_dict,
+)
 from langgraph.checkpoint.postgres import PostgresSaver
 from langgraph.graph import MessagesState, StateGraph, START, END
 
@@ -130,6 +135,154 @@ class PostgresChatManager:
             checkpoint_id=checkpoint_id,
             invoked=invoked,
         )
+
+    def stream_messages(
+        self, *, thread_id: str, messages: Sequence[Dict[str, Any]]
+    ) -> Iterator[Dict[str, Any]]:
+        """Stream assistant deltas for appended messages.
+
+        The returned iterator yields structured events (content deltas, tool call
+        chunks, and full message payloads) and ultimately returns a ``ChatResponse``
+        matching :meth:`send_messages` via ``StopIteration.value``.
+        """
+
+        tid = self._normalize_thread_id(thread_id)
+        cfg = {"configurable": {"thread_id": tid}}
+        incoming = [self._prepare_incoming_message(m) for m in messages if m]
+        if not incoming:
+            raise ValueError("No messages supplied for invocation.")
+        existing, existing_keys, _ = self._load_state(cfg)
+        incoming_keys = [self._compare_key(m) for m in incoming]
+        shared = self._shared_prefix(existing_keys, incoming_keys)
+        new_payloads = incoming[shared:]
+        invoked = bool(new_payloads)
+        callbacks = list(get_langsmith_callbacks())
+        graph_config: Dict[str, Any] = dict(cfg)
+        if callbacks:
+            graph_config = {**cfg, "callbacks": callbacks}
+        metadata = {
+            "thread_id": tid,
+            "incoming_count": len(incoming),
+            "new_payloads": len(new_payloads),
+            "shared_prefix": shared,
+            "invoked": invoked,
+        }
+
+        def _unpack_stream_item(event: Any) -> Tuple[Any, Optional[Dict[str, Any]]]:
+            if isinstance(event, tuple) and len(event) == 2:
+                return event[0], event[1]
+            if isinstance(event, dict) and "payload" in event and "metadata" in event:
+                return event["payload"], event.get("metadata")
+            return event, None
+
+        def _content_from_chunk(chunk: AIMessageChunk) -> str:
+            try:
+                return self._coerce_content(chunk.content)
+            except Exception:
+                return str(chunk.content or "")
+
+        def _emit_events() -> Iterator[Dict[str, Any]]:
+            with trace_run("law.chat.stream_messages", metadata=metadata):
+                if not invoked:
+                    updated, _, snapshot = self._load_state(cfg)
+                    response = self._last_assistant(updated)
+                    checkpoint_id = self._extract_checkpoint_id(snapshot)
+                    metadata["checkpoint_id"] = checkpoint_id
+                    metadata["response_available"] = bool(response)
+                    return ChatResponse(
+                        thread_id=tid,
+                        messages=updated,
+                        response=response,
+                        checkpoint_id=checkpoint_id,
+                        invoked=invoked,
+                    )
+
+                graph = self._ensure_graph()
+                stream_fn = getattr(graph, "stream", None)
+                using_graph_stream = callable(stream_fn)
+                aggregated_chunk: Optional[AIMessageChunk] = None
+                aggregated_message: Optional[BaseMessage] = None
+
+                iterator: Optional[Iterator[Any]] = None
+                if using_graph_stream:
+                    try:
+                        iterator = stream_fn(
+                            {"messages": new_payloads},
+                            graph_config,
+                            stream_mode="messages",
+                        )
+                    except TypeError:
+                        iterator = stream_fn({"messages": new_payloads}, graph_config)
+                if iterator is None:
+                    using_graph_stream = False
+                    history_objects = messages_from_dict(existing)
+                    incoming_objects = messages_from_dict(new_payloads)
+                    if incoming_objects:
+                        graph.update_state(
+                            cfg, {"messages": incoming_objects}, as_node=START
+                        )
+                    iterator = self._model.stream(history_objects + incoming_objects)
+
+                try:
+                    for raw in iterator:
+                        payload, info = _unpack_stream_item(raw)
+                        event_metadata = {"metadata": info} if info else {}
+                        if isinstance(payload, AIMessageChunk):
+                            aggregated_chunk = (
+                                payload
+                                if aggregated_chunk is None
+                                else aggregated_chunk + payload
+                            )
+                            text_delta = _content_from_chunk(payload)
+                            if text_delta:
+                                yield {
+                                    "type": "content_delta",
+                                    "payload": text_delta,
+                                    **event_metadata,
+                                }
+                            tool_chunks = getattr(payload, "tool_call_chunks", None)
+                            if tool_chunks:
+                                yield {
+                                    "type": "tool_call_chunk",
+                                    "payload": list(tool_chunks),
+                                    **event_metadata,
+                                }
+                        elif isinstance(payload, BaseMessage):
+                            aggregated_message = payload
+                            yield {
+                                "type": "message",
+                                "payload": self._message_to_dict(payload),
+                                **event_metadata,
+                            }
+                        else:
+                            yield {"type": "raw", "payload": payload, **event_metadata}
+                finally:
+                    if not using_graph_stream:
+                        final_message: Optional[BaseMessage] = aggregated_message
+                        if final_message is None and aggregated_chunk is not None:
+                            final_message = message_chunk_to_message(aggregated_chunk)
+                        if final_message is not None:
+                            graph.update_state(
+                                cfg,
+                                {"messages": [final_message]},
+                                as_node="chat_model",
+                            )
+
+                    updated, _, snapshot = self._load_state(cfg)
+                    response = self._last_assistant(updated)
+                    checkpoint_id = self._extract_checkpoint_id(snapshot)
+                    metadata["checkpoint_id"] = checkpoint_id
+                    metadata["response_available"] = bool(response)
+
+                return ChatResponse(
+                    thread_id=tid,
+                    messages=updated,
+                    response=response,
+                    checkpoint_id=metadata.get("checkpoint_id"),
+                    invoked=invoked,
+                )
+
+        return _emit_events()
 
     def get_messages(self, thread_id: str) -> List[Dict[str, Any]]:
         """Return the current message state for a thread."""
@@ -335,7 +488,7 @@ class PostgresChatManager:
             raise ValueError("thread_id must be a non-empty string.")
         if len(tid) > 200:
             raise ValueError("thread_id is too long (max 200 characters).")
-        if ' ' in tid:
+        if " " in tid:
             raise ValueError("thread_id cannot contain space characters.")
         return tid
 

--- a/tests/test_streaming_tool_calls.py
+++ b/tests/test_streaming_tool_calls.py
@@ -1,20 +1,29 @@
 from __future__ import annotations
 
-import json
 import io
+import json
 from dataclasses import dataclass
-from typing import Any, Dict
+from types import SimpleNamespace
+from typing import Any, Dict, Iterator, List, Optional
 
 import pytest
 
 pytest.importorskip("langchain")
+
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    HumanMessage,
+    ToolCall,
+    ToolCallChunk,
+)
 
 from packages.legal_tools.api_server import (
     ChatHandler,
     _normalize_tool_call_chunk,
     _normalize_tool_calls,
 )
-from packages.legal_tools.multi_turn_chat import PostgresChatManager
+from packages.legal_tools.multi_turn_chat import ChatResponse, PostgresChatManager
 
 
 def _make_manager() -> PostgresChatManager:
@@ -34,7 +43,7 @@ def test_normalize_tool_calls_converts_args_to_strings() -> None:
         {"id": "call_1", "name": "multiply", "args": {"a": 3, "b": 12}},
         {
             "tool_call_id": "call_2",
-            "function": {"name": "add", "arguments": "{\"a\": 11}"},
+            "function": {"name": "add", "arguments": '{"a": 11}'},
         },
     ]
 
@@ -44,12 +53,12 @@ def test_normalize_tool_calls_converts_args_to_strings() -> None:
         {
             "id": "call_1",
             "type": "function",
-            "function": {"name": "multiply", "arguments": "{\"a\": 3, \"b\": 12}"},
+            "function": {"name": "multiply", "arguments": '{"a": 3, "b": 12}'},
         },
         {
             "id": "call_2",
             "type": "function",
-            "function": {"name": "add", "arguments": "{\"a\": 11}"},
+            "function": {"name": "add", "arguments": '{"a": 11}'},
         },
     ]
 
@@ -71,7 +80,9 @@ def test_normalize_tool_calls_handles_empty_iterables() -> None:
     assert _normalize_tool_calls(None) == []
 
 
-def test_normalize_tool_calls_skips_malformed_entries(caplog: pytest.LogCaptureFixture) -> None:
+def test_normalize_tool_calls_skips_malformed_entries(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     normalized = _normalize_tool_calls([object()])
 
     assert normalized == []
@@ -84,7 +95,7 @@ def test_prepare_incoming_message_preserves_tool_call_chunks() -> None:
         "role": "assistant",
         "content": "",
         "tool_calls": [{"name": "Multiply"}],
-        "tool_call_chunks": [{"index": 0, "args": "{\"a\": 1}"}],
+        "tool_call_chunks": [{"index": 0, "args": '{"a": 1}'}],
     }
 
     prepared = manager._prepare_incoming_message(message)
@@ -104,7 +115,7 @@ def test_message_to_dict_retains_tool_call_chunks() -> None:
         "role": "assistant",
         "content": "result",
         "tool_calls": [{"name": "Add"}],
-        "tool_call_chunks": [{"index": 1, "args": "{\"b\": 2}"}],
+        "tool_call_chunks": [{"index": 1, "args": '{"b": 2}'}],
     }
 
     as_dict = manager._message_to_dict(message)
@@ -122,7 +133,7 @@ def test_message_to_dict_handles_message_objects() -> None:
             self.role = "assistant"
             self.content = "object-result"
             self.tool_calls = [{"name": "Add"}]
-            self.tool_call_chunks = [{"index": 2, "args": "{\"c\": 3}"}]
+            self.tool_call_chunks = [{"index": 2, "args": '{"c": 3}'}]
             self.tool_call_id = "call_object"
             self.additional_kwargs = {"foo": "bar"}
 
@@ -136,6 +147,154 @@ def test_message_to_dict_handles_message_objects() -> None:
     assert as_dict["tool_call_chunks"] == message.tool_call_chunks
     assert as_dict["tool_call_id"] == message.tool_call_id
     assert as_dict["additional_kwargs"] == message.additional_kwargs
+
+
+def test_stream_messages_streams_tool_calls_before_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _make_manager()
+
+    class FakeGraph:
+        def __init__(self) -> None:
+            self.messages: List[Dict[str, Any]] = []
+            self.checkpoint_id = "chk_test"
+
+        def get_state(self, cfg: Dict[str, Any]) -> SimpleNamespace:
+            return SimpleNamespace(
+                values={"messages": list(self.messages)},
+                config={"configurable": {"checkpoint_id": self.checkpoint_id}},
+            )
+
+        def update_state(
+            self,
+            cfg: Dict[str, Any],
+            payload: Dict[str, Any],
+            *,
+            as_node: Optional[str] = None,
+        ) -> None:
+            for message in payload.get("messages") or []:
+                if hasattr(message, "dict"):
+                    self.messages.append(message.dict())
+                elif isinstance(message, dict):
+                    self.messages.append(dict(message))
+                else:
+                    self.messages.append({"role": "assistant", "content": str(message)})
+
+        def get_state_history(self, cfg: Dict[str, Any]) -> List[Any]:
+            return []
+
+    fake_graph = FakeGraph()
+    manager._graph = fake_graph  # type: ignore[attr-defined]
+    manager._ensure_graph = lambda: fake_graph  # type: ignore[assignment]
+
+    def fake_load_state(cfg: Dict[str, Any]) -> Any:
+        snapshot = fake_graph.get_state(cfg)
+        messages = [
+            manager._message_to_dict(msg) for msg in snapshot.values["messages"]
+        ]
+        keys = [manager._compare_key(msg) for msg in messages]
+        return messages, keys, snapshot
+
+    manager._load_state = fake_load_state  # type: ignore[assignment]
+    manager._extract_checkpoint_id = (
+        lambda snapshot: snapshot.config["configurable"].get("checkpoint_id")
+        if snapshot
+        else None
+    )
+
+    monkeypatch.setattr(
+        "packages.legal_tools.multi_turn_chat.get_langsmith_callbacks",
+        lambda: [],
+    )
+
+    def fake_messages_from_dict(messages: List[Dict[str, Any]]) -> List[Any]:
+        results: List[Any] = []
+        for message in messages:
+            role = (message.get("role") or message.get("type") or "").lower()
+            content = message.get("content", "")
+            if role in {"user", "human"}:
+                results.append(HumanMessage(content=content))
+            else:
+                results.append(AIMessage(content=content))
+        return results
+
+    monkeypatch.setattr(
+        "packages.legal_tools.multi_turn_chat.messages_from_dict",
+        fake_messages_from_dict,
+    )
+
+    class FakeModel:
+        def stream(self, messages: List[Any]) -> Iterator[Any]:
+            yield AIMessageChunk(
+                content="",
+                tool_call_chunks=[
+                    ToolCallChunk(
+                        name="multiply",
+                        args='{"a": 1}',
+                        index=0,
+                        id="call_1",
+                    )
+                ],
+            )
+            yield AIMessageChunk(content="final result")
+            yield AIMessage(
+                content="final result",
+                tool_calls=[
+                    ToolCall(name="multiply", args={"a": 1, "b": 2}, id="call_1")
+                ],
+                tool_call_chunks=[
+                    ToolCallChunk(
+                        name="multiply",
+                        args='{"a": 1, "b": 2}',
+                        index=0,
+                        id="call_1",
+                    )
+                ],
+            )
+
+    manager._model = FakeModel()  # type: ignore[attr-defined]
+
+    iterator = manager.stream_messages(
+        thread_id="thread-1",
+        messages=[{"role": "user", "content": "calc"}],
+    )
+
+    events: List[Dict[str, Any]] = []
+    response: Optional[ChatResponse] = None
+    while True:
+        try:
+            events.append(next(iterator))
+        except StopIteration as stop:
+            response = stop.value
+            break
+
+    assert response is not None
+    assert response.response is not None
+    tool_chunk_indexes = [
+        idx
+        for idx, event in enumerate(events)
+        if event.get("type") == "tool_call_chunk"
+    ]
+    content_indexes = [
+        idx for idx, event in enumerate(events) if event.get("type") == "content_delta"
+    ]
+    assert tool_chunk_indexes and content_indexes, (
+        "Expected both tool and content events"
+    )
+    assert tool_chunk_indexes[0] < content_indexes[0], (
+        "Tool call delta must precede textual content"
+    )
+    assert events[tool_chunk_indexes[0]]["payload"][0]["id"] == "call_1"
+    assert events[content_indexes[0]]["payload"] == "final result"
+
+    final_payload = response.response
+    assert final_payload.get("tool_calls"), "Chat history should record tool calls"
+    assert final_payload.get("tool_call_chunks"), (
+        "Chat history should record chunk details"
+    )
+    assert any(msg.get("tool_call_chunks") for msg in fake_graph.messages), (
+        "Graph state should persist tool call chunks"
+    )
 
 
 def test_stream_answer_emits_tool_call_chunk_events() -> None:
@@ -159,44 +318,69 @@ def test_stream_answer_emits_tool_call_chunk_events() -> None:
             payload = json.dumps(obj, ensure_ascii=False)
             self.wfile.write(f"data: {payload}\n\n".encode("utf-8"))
 
+        def _collect_tool_usage(
+            self,
+            *,
+            agent_result: Optional[Dict[str, Any]],
+            chat_result: Optional[ChatResponse],
+        ) -> Optional[Dict[str, Any]]:
+            return None
+
     handler = DummyHandler()
     tool_calls = [
         {
             "id": "call_1",
             "type": "function",
-            "function": {"name": "multiply", "arguments": "{\"a\": 1, \"b\": 2}"},
+            "function": {"name": "multiply", "arguments": '{"a": 1, "b": 2}'},
         }
     ]
-    tool_call_chunks = [
-        {
-            "choices": [
-                {
-                    "delta": {
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": "call_1",
-                                "type": "function",
-                                "function": {
-                                    "name": "multiply",
-                                    "arguments": "{\"a\": 1",
-                                },
-                            }
-                        ]
-                    }
+    tool_call_delta = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "multiply",
+                                "arguments": '{"a": 1',
+                            },
+                        }
+                    ]
                 }
-            ]
-        }
-    ]
+            }
+        ]
+    }
 
-    ChatHandler._stream_answer(  # type: ignore[arg-type]
+    def event_iterator() -> Iterator[Dict[str, Any]]:
+        yield {"type": "tool_call_chunk", "payload": tool_call_delta}
+        yield {"type": "content_delta", "payload": "final result"}
+        return ChatResponse(
+            thread_id="thread-1",
+            messages=[],
+            response={
+                "role": "assistant",
+                "content": "final result",
+                "tool_calls": tool_calls,
+            },
+            checkpoint_id=None,
+            invoked=True,
+        )
+
+    final_response = ChatHandler._stream_answer(  # type: ignore[arg-type]
         handler,
         chat_id="chat-123",
         model="test-model",
         created=1,
-        answer="final result",
+        thread_id="thread-1",
         tool_calls=tool_calls,
-        tool_call_chunks=tool_call_chunks,
+        tool_call_chunks=None,
+        fallback_answer="",
+        event_iterator=event_iterator(),
+        agent_result=None,
+        chat_result=None,
     )
 
     raw = handler.wfile.getvalue().decode("utf-8")
@@ -213,22 +397,31 @@ def test_stream_answer_emits_tool_call_chunk_events() -> None:
 
     assert done_seen, "Streaming response must terminate with [DONE] marker"
 
-    tool_call_deltas = []
-    for payload in payloads:
+    tool_delta_index: Optional[int] = None
+    content_index: Optional[int] = None
+    for idx, payload in enumerate(payloads):
         choices = payload.get("choices") or []
         if not choices:
             continue
         delta = choices[0].get("delta") or {}
-        if "tool_calls" in delta:
-            tool_call_deltas.append(delta["tool_calls"])
+        if tool_delta_index is None and delta.get("tool_calls"):
+            tool_delta_index = idx
+        if content_index is None and delta.get("content"):
+            content_index = idx
 
-    assert len(tool_call_deltas) >= 2
-    chunk_arguments = [
-        calls[0]["function"]["arguments"]
-        for calls in tool_call_deltas
-        if calls and "function" in calls[0]
-    ]
-    assert "{\"a\": 1" in chunk_arguments
+    assert tool_delta_index is not None and content_index is not None
+    assert tool_delta_index < content_index, (
+        "Tool call chunk must arrive before content"
+    )
+
+    final_chunk = payloads[-1]
+    assert final_chunk.get("law", {}).get("tool_call_chunks")
+    law_chunks = final_chunk["law"]["tool_call_chunks"]
+    assert law_chunks[0]["choices"][0]["delta"]["tool_calls"][0]["id"] == "call_1"
+
+    assert isinstance(final_response, ChatResponse)
+    assert final_response.response is not None
+    assert "tool_call_chunks" not in final_response.response
 
 
 def test_normalize_tool_call_chunk_flattens_delta_shapes() -> None:
@@ -255,4 +448,4 @@ def test_normalize_tool_call_chunk_flattens_delta_shapes() -> None:
     call = normalized[0]
     assert call["id"] == "call_42"
     assert call["function"]["name"] == "lookup"
-    assert call["function"]["arguments"] == "{\"q\": \"law\"}"
+    assert call["function"]["arguments"] == '{"q": "law"}'


### PR DESCRIPTION
## Summary
- add a stream_messages generator to PostgresChatManager that reuses the existing thread normalization and prefix detection
- surface structured content/tool call events while delegating to LangGraph streaming, with a fallback to direct model streaming
- accumulate streamed payloads so the final AI message is persisted with the Postgres checkpointer and returned as ChatResponse metadata

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_68d8d62d50b48321af246921ce41d231

## Summary by Sourcery

Add streaming support to PostgreSQL-based chat manager by introducing a stream_messages generator that yields structured content and tool call events, integrates with LangGraph when available (with fallback to direct model streaming), and persists the final AI message via the existing Postgres checkpointer.

New Features:
- Introduce stream_messages method in PostgresChatManager to stream assistant responses.

Enhancements:
- Reuse thread normalization and shared-prefix detection for incoming messages.
- Emit structured events for content deltas, tool call chunks, full messages, and raw payloads.
- Fallback to direct model streaming when LangGraph streaming is unavailable.
- Accumulate streamed chunks into a final AI message and persist it with the Postgres checkpointer.