### PR TITLE
fix(auth): redirect unauthenticated users to login

### DIFF
--- a/packages/ai_frontend/app/(auth)/actions.ts
+++ b/packages/ai_frontend/app/(auth)/actions.ts
@@ -25,10 +25,17 @@ export const login = async (
       password: formData.get("password"),
     });
 
+    const redirectUrl = formData.get("redirectUrl");
+    const callbackUrl =
+      typeof redirectUrl === "string" && redirectUrl.startsWith("/")
+        ? redirectUrl
+        : undefined;
+
     await signIn("credentials", {
       email: validatedData.email,
       password: validatedData.password,
       redirect: false,
+      ...(callbackUrl ? { callbackUrl } : {}),
     });
 
     return { status: "success" };
@@ -67,10 +74,18 @@ export const register = async (
       return { status: "user_exists" } as RegisterActionState;
     }
     await createUser(validatedData.email, validatedData.password);
+
+    const redirectUrl = formData.get("redirectUrl");
+    const callbackUrl =
+      typeof redirectUrl === "string" && redirectUrl.startsWith("/")
+        ? redirectUrl
+        : undefined;
+
     await signIn("credentials", {
       email: validatedData.email,
       password: validatedData.password,
       redirect: false,
+      ...(callbackUrl ? { callbackUrl } : {}),
     });
 
     return { status: "success" };

--- a/packages/ai_frontend/app/(auth)/login/page.tsx
+++ b/packages/ai_frontend/app/(auth)/login/page.tsx
@@ -14,8 +14,9 @@ export default function Page() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirectParam = searchParams.get("redirectUrl");
-  const nextPath =
-    redirectParam && redirectParam.startsWith("/") ? redirectParam : "/";
+  const sanitizedRedirectParam =
+    redirectParam && redirectParam.startsWith("/") ? redirectParam : null;
+  const nextPath = sanitizedRedirectParam ?? "/";
 
   const [email, setEmail] = useState("");
   const [isSuccessful, setIsSuccessful] = useState(false);
@@ -49,6 +50,9 @@ export default function Page() {
 
   const handleSubmit = (formData: FormData) => {
     setEmail(formData.get("email") as string);
+    if (sanitizedRedirectParam) {
+      formData.set("redirectUrl", sanitizedRedirectParam);
+    }
     formAction(formData);
   };
 

--- a/packages/ai_frontend/middleware.ts
+++ b/packages/ai_frontend/middleware.ts
@@ -30,6 +30,10 @@ export async function middleware(request: NextRequest) {
       return NextResponse.next();
     }
 
+    if (pathname.startsWith("/api")) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+
     const redirectPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
     const safeRedirect = redirectPath || "/";
 


### PR DESCRIPTION
## Summary
- return 401 JSON errors from middleware for unauthenticated API requests while redirecting browser traffic to the login page
- plumb optional redirectUrl through the login flow so sign-in honors the original destination
- keep sign-in server actions aligned with optional callback URLs for both login and registration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e41629548321a3c487294c1140a5