### PR TITLE
refactor: remove guest fallbacks and simplify entitlements

### DIFF
--- a/packages/ai_frontend/app/(chat)/api/chat/route.ts
+++ b/packages/ai_frontend/app/(chat)/api/chat/route.ts
@@ -18,7 +18,7 @@ import { fetchModels } from "tokenlens/fetch";
 import { getUsage } from "tokenlens/helpers";
 import { auth, type UserType } from "@/app/(auth)/auth";
 import type { VisibilityType } from "@/components/visibility-selector";
-import { entitlementsByUserType } from "@/lib/ai/entitlements";
+import { getEntitlementsForUserType } from "@/lib/ai/entitlements";
 import type { ChatModel } from "@/lib/ai/models";
 import { type RequestHints, systemPrompt } from "@/lib/ai/prompts";
 import { myProvider } from "@/lib/ai/providers";
@@ -120,7 +120,7 @@ export async function POST(request: Request) {
       differenceInHours: 24,
     });
 
-    if (messageCount > entitlementsByUserType[userType].maxMessagesPerDay) {
+    if (messageCount > getEntitlementsForUserType(userType).maxMessagesPerDay) {
       return new ChatSDKError("rate_limit:chat").toResponse();
     }
 

--- a/packages/ai_frontend/components/app-sidebar.tsx
+++ b/packages/ai_frontend/components/app-sidebar.tsx
@@ -62,7 +62,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
       <SidebarContent>
         <SidebarHistory user={user} />
       </SidebarContent>
-      <SidebarFooter>{user && <SidebarUserNav user={user} />}</SidebarFooter>
+      <SidebarFooter>{user && <SidebarUserNav />}</SidebarFooter>
     </Sidebar>
   );
 }

--- a/packages/ai_frontend/components/model-selector.tsx
+++ b/packages/ai_frontend/components/model-selector.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { entitlementsByUserType } from "@/lib/ai/entitlements";
+import { getEntitlementsForUserType } from "@/lib/ai/entitlements";
 import { chatModels } from "@/lib/ai/models";
 import { cn } from "@/lib/utils";
 import { CheckCircleFillIcon, ChevronDownIcon } from "./icons";
@@ -28,7 +28,7 @@ export function ModelSelector({
     useOptimistic(selectedModelId);
 
   const userType = session.user.type;
-  const { availableChatModelIds } = entitlementsByUserType[userType];
+  const { availableChatModelIds } = getEntitlementsForUserType(userType);
 
   const availableChatModels = chatModels.filter((chatModel) =>
     availableChatModelIds.includes(chatModel.id)

--- a/packages/ai_frontend/components/sidebar-user-nav.tsx
+++ b/packages/ai_frontend/components/sidebar-user-nav.tsx
@@ -2,7 +2,6 @@
 
 import { ChevronUp } from "lucide-react";
 import Image from "next/image";
-import type { User } from "next-auth";
 import { signOut, useSession } from "next-auth/react";
 import { useTheme } from "next-themes";
 import {
@@ -20,10 +19,11 @@ import {
 import { LoaderIcon } from "./icons";
 import { toast } from "./toast";
 
-export function SidebarUserNav({ user }: { user: User }) {
+export function SidebarUserNav() {
   const { data, status } = useSession();
   const { setTheme, resolvedTheme } = useTheme();
-  const displayEmail = data?.user?.email ?? user.email ?? "Account";
+  const email = data?.user?.email;
+  const displayEmail = email ?? "Account";
 
   return (
     <SidebarMenu>
@@ -48,10 +48,10 @@ export function SidebarUserNav({ user }: { user: User }) {
                 data-testid="user-nav-button"
               >
                 <Image
-                  alt={user.email ?? "User Avatar"}
+                  alt={email ?? "User Avatar"}
                   className="rounded-full"
                   height={24}
-                  src={`https://avatar.vercel.sh/${user.email}`}
+                  src={`https://avatar.vercel.sh/${email ?? "user"}`}
                   width={24}
                 />
                 <span className="truncate" data-testid="user-email">

--- a/packages/ai_frontend/lib/ai/entitlements.ts
+++ b/packages/ai_frontend/lib/ai/entitlements.ts
@@ -1,25 +1,27 @@
 import type { UserType } from "@/app/(auth)/auth";
 import type { ChatModel } from "./models";
 
-type Entitlements = {
+export type Entitlements = {
   maxMessagesPerDay: number;
   availableChatModelIds: ChatModel["id"][];
 };
 
-export const entitlementsByUserType: Record<UserType, Entitlements> = {
-  /*
-   * For users with an account
-   */
-  regular: {
-    maxMessagesPerDay: 100,
-    availableChatModelIds: ["chat-model", "chat-model-reasoning"],
-  },
+const REGULAR_ENTITLEMENTS: Entitlements = {
+  maxMessagesPerDay: 100,
+  availableChatModelIds: ["chat-model", "chat-model-reasoning"],
+};
 
-  /*
-   * For users with an account and a paid membership
-   */
-  premium: {
-    maxMessagesPerDay: 1000,
-    availableChatModelIds: ["chat-model", "chat-model-reasoning"],
-  },
+const PREMIUM_ENTITLEMENTS: Entitlements = {
+  maxMessagesPerDay: 1000,
+  availableChatModelIds: ["chat-model", "chat-model-reasoning"],
+};
+
+export const getEntitlementsForUserType = (
+  userType: UserType
+): Entitlements => {
+  if (userType === "premium") {
+    return PREMIUM_ENTITLEMENTS;
+  }
+
+  return REGULAR_ENTITLEMENTS;
 };

--- a/packages/ai_frontend/tests/e2e/session.test.ts
+++ b/packages/ai_frontend/tests/e2e/session.test.ts
@@ -19,13 +19,32 @@ test.describe
       );
     });
 
-    test("Allow navigating to /login when unauthenticated", async ({ page }) => {
+    test("Redirect guest endpoint to login when unauthenticated", async ({
+      page,
+    }) => {
+      const response = await page.goto("/api/auth/guest");
+
+      if (!response) {
+        throw new Error("Failed to load guest endpoint");
+      }
+
+      await page.waitForURL("/login?redirectUrl=%2F");
+      await expect(page).toHaveURL(
+        "http://localhost:3000/login?redirectUrl=%2F"
+      );
+    });
+
+    test("Allow navigating to /login when unauthenticated", async ({
+      page,
+    }) => {
       await page.goto("/login");
       await page.waitForURL("/login");
       await expect(page).toHaveURL("/login");
     });
 
-    test("Allow navigating to /register when unauthenticated", async ({ page }) => {
+    test("Allow navigating to /register when unauthenticated", async ({
+      page,
+    }) => {
       await page.goto("/register");
       await page.waitForURL("/register");
       await expect(page).toHaveURL("/register");
@@ -73,7 +92,7 @@ test.describe
       await authPage.logout(testUser.email, testUser.password);
     });
 
-    test("Legacy guest endpoint preserves authenticated session", async ({
+    test("Guest endpoint keeps authenticated session active", async ({
       page,
     }) => {
       await authPage.login(testUser.email, testUser.password);


### PR DESCRIPTION
## Summary
- update the sidebar user menu to rely on the authenticated session email and drop guest fallbacks
- collapse the entitlements helper into a single accessor and update the chat API and model selector
- tighten guest endpoint e2e coverage to ensure it redirects unauthenticated users to login while keeping logged-in sessions intact

## Testing
- pnpm lint *(fails: pre-existing lint offenses unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e53af2008321a173122190e0359d