### PR TITLE
fix(auth): ensure NextAuth has a development secret

### DIFF
--- a/packages/ai_frontend/app/(auth)/api/auth/guest/route.ts
+++ b/packages/ai_frontend/app/(auth)/api/auth/guest/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
+import { getAuthSecret } from "@/lib/auth";
 import { isDevelopmentEnvironment } from "@/lib/constants";
 
 export async function GET(request: Request) {
@@ -24,7 +25,7 @@ export async function GET(request: Request) {
 
   const token = await getToken({
     req: request,
-    secret: process.env.AUTH_SECRET,
+    secret: getAuthSecret(),
     secureCookie: !isDevelopmentEnvironment,
   });
 

--- a/packages/ai_frontend/app/(auth)/auth.config.ts
+++ b/packages/ai_frontend/app/(auth)/auth.config.ts
@@ -1,6 +1,8 @@
 import type { NextAuthConfig } from "next-auth";
+import { getAuthSecret } from "@/lib/auth";
 
 export const authConfig = {
+  secret: getAuthSecret(),
   pages: {
     signIn: "/login",
     newUser: "/",

--- a/packages/ai_frontend/lib/auth.ts
+++ b/packages/ai_frontend/lib/auth.ts
@@ -1,0 +1,21 @@
+const FALLBACK_AUTH_SECRET = "development-auth-secret";
+
+function isProduction() {
+  return process.env.NODE_ENV === "production";
+}
+
+export function getAuthSecret(): string {
+  const envSecret = process.env.AUTH_SECRET?.trim();
+
+  if (envSecret && envSecret.length > 0) {
+    return envSecret;
+  }
+
+  if (isProduction()) {
+    throw new Error(
+      "AUTH_SECRET environment variable is required when running in production"
+    );
+  }
+
+  return FALLBACK_AUTH_SECRET;
+}

--- a/packages/ai_frontend/lib/auth.ts
+++ b/packages/ai_frontend/lib/auth.ts
@@ -5,10 +5,21 @@ function isProduction() {
 }
 
 export function getAuthSecret(): string {
-  const envSecret = process.env.AUTH_SECRET?.trim();
+  const rawEnvSecret = process.env.AUTH_SECRET;
 
-  if (envSecret && envSecret.length > 0) {
-    return envSecret;
+  if (rawEnvSecret !== undefined) {
+    if (
+      rawEnvSecret.length > 0 &&
+      (rawEnvSecret !== rawEnvSecret.trim())
+    ) {
+      console.warn(
+        "AUTH_SECRET environment variable contains leading or trailing whitespace. This may indicate a configuration error."
+      );
+    }
+    const envSecret = rawEnvSecret.trim();
+    if (envSecret.length > 0) {
+      return envSecret;
+    }
   }
 
   if (isProduction()) {

--- a/packages/ai_frontend/middleware.ts
+++ b/packages/ai_frontend/middleware.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
+import { getAuthSecret } from "./lib/auth";
 import { isDevelopmentEnvironment } from "./lib/constants";
 
 export async function middleware(request: NextRequest) {
@@ -19,7 +20,7 @@ export async function middleware(request: NextRequest) {
 
   const token = await getToken({
     req: request,
-    secret: process.env.AUTH_SECRET,
+    secret: getAuthSecret(),
     secureCookie: !isDevelopmentEnvironment,
   });
 


### PR DESCRIPTION
## Summary
- add a shared helper that derives the Auth.js secret with a safe development fallback
- wire the helper into NextAuth config, middleware, and guest auth route so session fetches return JSON instead of server errors

## Testing
- pnpm lint *(fails: existing optional chaining and formatting warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d90cca7f4083219671cbf34197e0e5

## Summary by Sourcery

Provide a safe development fallback for the NextAuth secret and integrate it across the application

Bug Fixes:
- Prevent NextAuth from failing when AUTH_SECRET is missing in development by supplying a default secret

Enhancements:
- Add getAuthSecret helper that returns the environment secret or a development fallback and throws in production
- Replace direct process.env.AUTH_SECRET usage with getAuthSecret in the NextAuth configuration, middleware, and guest auth route