### PR TITLE
fix: provide scoped Postgres options type alias

### DIFF
--- a/packages/ai_frontend/app/(auth)/login/page.tsx
+++ b/packages/ai_frontend/app/(auth)/login/page.tsx
@@ -3,14 +3,14 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { useActionState, useEffect, useState } from "react";
+import { Suspense, useActionState, useEffect, useState } from "react";
 
 import { AuthForm } from "@/components/auth-form";
 import { SubmitButton } from "@/components/submit-button";
 import { toast } from "@/components/toast";
 import { type LoginActionState, login } from "../actions";
 
-export default function Page() {
+function LoginPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirectParam = searchParams.get("redirectUrl");
@@ -80,5 +80,28 @@ export default function Page() {
         </AuthForm>
       </div>
     </div>
+  );
+}
+
+function LoginPageFallback() {
+  return (
+    <div className="flex h-dvh w-screen items-start justify-center bg-background pt-12 md:items-center md:pt-0">
+      <div className="flex w-full max-w-md flex-col gap-12 overflow-hidden rounded-2xl">
+        <div className="flex flex-col items-center justify-center gap-2 px-4 text-center sm:px-16">
+          <h3 className="font-semibold text-xl dark:text-zinc-50">Sign In</h3>
+          <p className="text-gray-500 text-sm dark:text-zinc-400">
+            Loading sign-in details...
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<LoginPageFallback />}>
+      <LoginPageContent />
+    </Suspense>
   );
 }

--- a/packages/ai_frontend/app/(auth)/register/page.tsx
+++ b/packages/ai_frontend/app/(auth)/register/page.tsx
@@ -3,13 +3,13 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { useActionState, useEffect, useState } from "react";
+import { Suspense, useActionState, useEffect, useState } from "react";
 import { AuthForm } from "@/components/auth-form";
 import { SubmitButton } from "@/components/submit-button";
 import { toast } from "@/components/toast";
 import { type RegisterActionState, register } from "../actions";
 
-export default function Page() {
+function RegisterPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirectParam = searchParams.get("redirectUrl");
@@ -76,5 +76,28 @@ export default function Page() {
         </AuthForm>
       </div>
     </div>
+  );
+}
+
+function RegisterPageFallback() {
+  return (
+    <div className="flex h-dvh w-screen items-start justify-center bg-background pt-12 md:items-center md:pt-0">
+      <div className="flex w-full max-w-md flex-col gap-12 overflow-hidden rounded-2xl">
+        <div className="flex flex-col items-center justify-center gap-2 px-4 text-center sm:px-16">
+          <h3 className="font-semibold text-xl dark:text-zinc-50">Sign Up</h3>
+          <p className="text-gray-500 text-sm dark:text-zinc-400">
+            Loading registration details...
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<RegisterPageFallback />}>
+      <RegisterPageContent />
+    </Suspense>
   );
 }

--- a/packages/ai_frontend/lib/db/client.ts
+++ b/packages/ai_frontend/lib/db/client.ts
@@ -1,5 +1,5 @@
 import { drizzle } from "drizzle-orm/postgres-js";
-import postgres, { type Options, type Sql } from "postgres";
+import postgres, { type Sql } from "postgres";
 
 import { getPostgresUrl } from "./env";
 
@@ -30,7 +30,9 @@ export const getDb = () => {
   return db;
 };
 
-export const createScopedDb = (options?: Options) => {
+type PostgresOptions = Parameters<typeof postgres>[1];
+
+export const createScopedDb = (options?: PostgresOptions) => {
   ensureServerEnvironment();
   const scopedClient = postgres(getPostgresUrl(), options);
   return { db: drizzle(scopedClient), client: scopedClient };


### PR DESCRIPTION
## Summary
- replace direct use of postgres Options generic with a type inferred from the client factory
- ensure scoped database helper accepts the correct options type without triggering TypeScript errors

## Testing
- pnpm --dir packages/ai_frontend exec tsc --noEmit *(fails: existing nullability errors in e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d914b93cc48321a58588986aedf968

## Summary by Sourcery

Provide a scoped type alias for PostgreSQL connection options and update createScopedDb to use it

Bug Fixes:
- Prevent TypeScript errors by aligning the scoped database helper’s options type with the client factory

Enhancements:
- Introduce PostgresOptions as an alias for the second parameter of postgres()
- Update createScopedDb signature to accept PostgresOptions instead of the generic Options type