### PR TITLE
feat(ai_frontend): add Vercel web analytics

### DIFF
--- a/packages/ai_frontend/app/layout.tsx
+++ b/packages/ai_frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "sonner";
 import { ThemeProvider } from "@/components/theme-provider";
+import { Analytics } from "@vercel/analytics/react";
 
 import "./globals.css";
 import { SessionProvider } from "next-auth/react";
@@ -80,6 +81,7 @@ export default function RootLayout({
         >
           <Toaster position="top-center" />
           <SessionProvider>{children}</SessionProvider>
+          <Analytics />
         </ThemeProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- import the Vercel Web Analytics client into the Next.js root layout
- render the Analytics component so page views are tracked by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da472d9b5c83219aac3c121d4f5e6a