### PR TITLE
feat(frontend): add chat onboarding flow

### DIFF
--- a/packages/ai_frontend/app/(chat)/actions.ts
+++ b/packages/ai_frontend/app/(chat)/actions.ts
@@ -15,6 +15,14 @@ export async function saveChatModelAsCookie(model: string) {
   cookieStore.set("chat-model", model);
 }
 
+export async function completeOnboarding() {
+  const cookieStore = await cookies();
+  cookieStore.set("onboarding-complete", "true", {
+    maxAge: 60 * 60 * 24 * 365, // 1 year
+    path: "/",
+  });
+}
+
 export async function generateTitleFromUserMessage({
   message,
 }: {

--- a/packages/ai_frontend/app/(chat)/chat/[id]/page.tsx
+++ b/packages/ai_frontend/app/(chat)/chat/[id]/page.tsx
@@ -41,32 +41,20 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
 
   const cookieStore = await cookies();
   const chatModelFromCookie = cookieStore.get("chat-model");
-
-  if (!chatModelFromCookie) {
-    return (
-      <>
-        <Chat
-          autoResume={true}
-          id={chat.id}
-          initialChatModel={DEFAULT_CHAT_MODEL}
-          initialLastContext={chat.lastContext ?? undefined}
-          initialMessages={uiMessages}
-          initialVisibilityType={chat.visibility}
-          isReadonly={session?.user?.id !== chat.userId}
-        />
-        <DataStreamHandler />
-      </>
-    );
-  }
+  const onboardingCompleteCookie = cookieStore.get("onboarding-complete");
+  const shouldShowOnboarding =
+    onboardingCompleteCookie?.value !== "true" && uiMessages.length === 0;
+  const initialChatModel = chatModelFromCookie?.value ?? DEFAULT_CHAT_MODEL;
 
   return (
     <>
       <Chat
         autoResume={true}
         id={chat.id}
-        initialChatModel={chatModelFromCookie.value}
+        initialChatModel={initialChatModel}
         initialLastContext={chat.lastContext ?? undefined}
         initialMessages={uiMessages}
+        initialShowOnboarding={shouldShowOnboarding}
         initialVisibilityType={chat.visibility}
         isReadonly={session?.user?.id !== chat.userId}
       />

--- a/packages/ai_frontend/app/(chat)/page.tsx
+++ b/packages/ai_frontend/app/(chat)/page.tsx
@@ -17,6 +17,8 @@ export default async function Page() {
 
   const cookieStore = await cookies();
   const modelIdFromCookie = cookieStore.get("chat-model");
+  const onboardingCompleteCookie = cookieStore.get("onboarding-complete");
+  const shouldShowOnboarding = onboardingCompleteCookie?.value !== "true";
 
   if (!modelIdFromCookie) {
     return (
@@ -26,6 +28,7 @@ export default async function Page() {
           id={id}
           initialChatModel={DEFAULT_CHAT_MODEL}
           initialMessages={[]}
+          initialShowOnboarding={shouldShowOnboarding}
           initialVisibilityType="private"
           isReadonly={false}
           key={id}
@@ -42,6 +45,7 @@ export default async function Page() {
         id={id}
         initialChatModel={modelIdFromCookie.value}
         initialMessages={[]}
+        initialShowOnboarding={shouldShowOnboarding}
         initialVisibilityType="private"
         isReadonly={false}
         key={id}

--- a/packages/ai_frontend/components/artifact.tsx
+++ b/packages/ai_frontend/components/artifact.tsx
@@ -52,6 +52,10 @@ export type UIArtifact = {
   };
 };
 
+const noop = () => {
+  return;
+};
+
 function PureArtifact({
   chatId,
   input,
@@ -68,6 +72,9 @@ function PureArtifact({
   isReadonly,
   selectedVisibilityType,
   selectedModelId,
+  isOnboardingActive = false,
+  onCompleteOnboarding,
+  isCompletingOnboarding = false,
 }: {
   chatId: string;
   input: string;
@@ -84,6 +91,9 @@ function PureArtifact({
   isReadonly: boolean;
   selectedVisibilityType: VisibilityType;
   selectedModelId: string;
+  isOnboardingActive?: boolean;
+  onCompleteOnboarding?: () => void;
+  isCompletingOnboarding?: boolean;
 }) {
   const { artifact, setArtifact, metadata, setMetadata } = useArtifact();
 
@@ -336,7 +346,10 @@ function PureArtifact({
                     chatId={chatId}
                     className="bg-background dark:bg-muted"
                     input={input}
+                    isCompletingOnboarding={isCompletingOnboarding}
+                    isOnboardingActive={isOnboardingActive}
                     messages={messages}
+                    onCompleteOnboarding={onCompleteOnboarding ?? noop}
                     selectedModelId={selectedModelId}
                     selectedVisibilityType={selectedVisibilityType}
                     sendMessage={sendMessage}
@@ -522,6 +535,15 @@ export const Artifact = memo(PureArtifact, (prevProps, nextProps) => {
     return false;
   }
   if (prevProps.selectedVisibilityType !== nextProps.selectedVisibilityType) {
+    return false;
+  }
+  if (prevProps.isOnboardingActive !== nextProps.isOnboardingActive) {
+    return false;
+  }
+  if (prevProps.isCompletingOnboarding !== nextProps.isCompletingOnboarding) {
+    return false;
+  }
+  if (prevProps.onCompleteOnboarding !== nextProps.onCompleteOnboarding) {
     return false;
   }
 

--- a/packages/ai_frontend/components/chat.tsx
+++ b/packages/ai_frontend/components/chat.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import { unstable_serialize } from "swr/infinite";
+import { completeOnboarding } from "@/app/(chat)/actions";
 import { ChatHeader } from "@/components/chat-header";
 import {
   AlertDialog,
@@ -25,7 +26,6 @@ import { ChatSDKError } from "@/lib/errors";
 import type { Attachment, ChatMessage } from "@/lib/types";
 import type { AppUsage } from "@/lib/usage";
 import { fetcher, fetchWithErrorHandlers, generateUUID } from "@/lib/utils";
-import { completeOnboarding } from "@/app/(chat)/actions";
 import { Artifact } from "./artifact";
 import { useDataStream } from "./data-stream-provider";
 import { Messages } from "./messages";
@@ -84,7 +84,7 @@ export function Chat({
         console.error("Failed to persist onboarding completion", error);
       });
     });
-  }, [showOnboarding, startCompleteOnboarding]);
+  }, [showOnboarding]);
 
   const {
     messages,
@@ -140,12 +140,6 @@ export function Chat({
     },
   });
 
-  useEffect(() => {
-    if (showOnboarding && messages.length > 0) {
-      handleCompleteOnboarding();
-    }
-  }, [handleCompleteOnboarding, messages.length, showOnboarding]);
-
   const searchParams = useSearchParams();
   const query = searchParams.get("query");
 
@@ -189,15 +183,15 @@ export function Chat({
 
         <Messages
           chatId={id}
-          isCompletingOnboarding={isCompletingOnboarding}
           isArtifactVisible={isArtifactVisible}
+          isCompletingOnboarding={isCompletingOnboarding}
           isReadonly={isReadonly}
           messages={messages}
           onCompleteOnboarding={handleCompleteOnboarding}
           regenerate={regenerate}
           selectedModelId={initialChatModel}
-          showOnboarding={showOnboarding}
           setMessages={setMessages}
+          showOnboarding={showOnboarding}
           status={status}
           votes={votes}
         />
@@ -207,9 +201,9 @@ export function Chat({
             <MultimodalInput
               attachments={attachments}
               chatId={id}
+              input={input}
               isCompletingOnboarding={isCompletingOnboarding}
               isOnboardingActive={showOnboarding}
-              input={input}
               messages={messages}
               onCompleteOnboarding={handleCompleteOnboarding}
               onModelChange={setCurrentModelId}
@@ -231,8 +225,11 @@ export function Chat({
         attachments={attachments}
         chatId={id}
         input={input}
+        isCompletingOnboarding={isCompletingOnboarding}
+        isOnboardingActive={showOnboarding}
         isReadonly={isReadonly}
         messages={messages}
+        onCompleteOnboarding={handleCompleteOnboarding}
         regenerate={regenerate}
         selectedModelId={currentModelId}
         selectedVisibilityType={visibilityType}

--- a/packages/ai_frontend/components/messages.tsx
+++ b/packages/ai_frontend/components/messages.tsx
@@ -9,6 +9,7 @@ import { useDataStream } from "./data-stream-provider";
 import { Conversation, ConversationContent } from "./elements/conversation";
 import { Greeting } from "./greeting";
 import { PreviewMessage, ThinkingMessage } from "./message";
+import { Onboarding } from "./onboarding";
 
 type MessagesProps = {
   chatId: string;
@@ -20,6 +21,9 @@ type MessagesProps = {
   isReadonly: boolean;
   isArtifactVisible: boolean;
   selectedModelId: string;
+  showOnboarding: boolean;
+  onCompleteOnboarding: () => void;
+  isCompletingOnboarding: boolean;
 };
 
 function PureMessages({
@@ -31,6 +35,9 @@ function PureMessages({
   regenerate,
   isReadonly,
   selectedModelId,
+  showOnboarding,
+  onCompleteOnboarding,
+  isCompletingOnboarding,
 }: MessagesProps) {
   const {
     containerRef: messagesContainerRef,
@@ -66,7 +73,17 @@ function PureMessages({
     >
       <Conversation className="mx-auto flex min-w-0 max-w-4xl flex-col gap-4 md:gap-6">
         <ConversationContent className="flex flex-col gap-4 px-2 py-4 md:gap-6 md:px-4">
-          {messages.length === 0 && <Greeting />}
+          {messages.length === 0 && (
+            showOnboarding ? (
+              <Onboarding
+                isCompleting={isCompletingOnboarding}
+                onComplete={onCompleteOnboarding}
+                onSkip={onCompleteOnboarding}
+              />
+            ) : (
+              <Greeting />
+            )
+          )}
 
           {messages.map((message, index) => (
             <PreviewMessage

--- a/packages/ai_frontend/components/multimodal-input.tsx
+++ b/packages/ai_frontend/components/multimodal-input.tsx
@@ -323,7 +323,6 @@ function PureMultimodalInput({
         <div className="flex flex-row items-start gap-1 sm:gap-2">
           <PromptInputTextarea
             autoFocus
-            aria-disabled={isOnboardingActive}
             className="grow resize-none border-0! border-none! bg-transparent p-2 text-sm outline-none ring-0 [-ms-overflow-style:none] [scrollbar-width:none] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-scrollbar]:hidden"
             data-testid="multimodal-input"
             disableAutoResize={true}
@@ -396,9 +395,7 @@ export const MultimodalInput = memo(
     if (prevProps.isOnboardingActive !== nextProps.isOnboardingActive) {
       return false;
     }
-    if (
-      prevProps.isCompletingOnboarding !== nextProps.isCompletingOnboarding
-    ) {
+    if (prevProps.isCompletingOnboarding !== nextProps.isCompletingOnboarding) {
       return false;
     }
 
@@ -414,13 +411,13 @@ function OnboardingQuickStart({
   isCompleting: boolean;
 }) {
   return (
-    <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-primary/40 bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-3 rounded-2xl border border-primary/40 border-dashed bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex flex-col gap-1">
-        <span className="flex items-center gap-2 font-medium text-sm text-primary">
+        <span className="flex items-center gap-2 font-medium text-primary text-sm">
           <Sparkles className="h-4 w-4" />
           온보딩을 마치고 시작해 보세요
         </span>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           주요 기능을 확인했다면 지금 바로 첫 질문을 남겨 보세요.
         </p>
       </div>

--- a/packages/ai_frontend/components/multimodal-input.tsx
+++ b/packages/ai_frontend/components/multimodal-input.tsx
@@ -4,6 +4,7 @@ import type { UseChatHelpers } from "@ai-sdk/react";
 import { Trigger } from "@radix-ui/react-select";
 import type { UIMessage } from "ai";
 import equal from "fast-deep-equal";
+import { Sparkles } from "lucide-react";
 import {
   type ChangeEvent,
   type Dispatch,
@@ -63,6 +64,9 @@ function PureMultimodalInput({
   selectedModelId,
   onModelChange,
   usage,
+  isOnboardingActive,
+  onCompleteOnboarding,
+  isCompletingOnboarding,
 }: {
   chatId: string;
   input: string;
@@ -79,6 +83,9 @@ function PureMultimodalInput({
   selectedModelId: string;
   onModelChange?: (modelId: string) => void;
   usage?: AppUsage;
+  isOnboardingActive: boolean;
+  onCompleteOnboarding: () => void;
+  isCompletingOnboarding: boolean;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
@@ -130,6 +137,10 @@ function PureMultimodalInput({
   const [uploadQueue, setUploadQueue] = useState<string[]>([]);
 
   const submitForm = useCallback(() => {
+    if (isOnboardingActive) {
+      return;
+    }
+
     window.history.replaceState({}, "", `/chat/${chatId}`);
 
     sendMessage({
@@ -166,6 +177,7 @@ function PureMultimodalInput({
     width,
     chatId,
     resetHeight,
+    isOnboardingActive,
   ]);
 
   const uploadFile = useCallback(async (file: File) => {
@@ -236,13 +248,19 @@ function PureMultimodalInput({
     <div className={cn("relative flex w-full flex-col gap-4", className)}>
       {messages.length === 0 &&
         attachments.length === 0 &&
-        uploadQueue.length === 0 && (
+        uploadQueue.length === 0 &&
+        (isOnboardingActive ? (
+          <OnboardingQuickStart
+            isCompleting={isCompletingOnboarding}
+            onComplete={onCompleteOnboarding}
+          />
+        ) : (
           <SuggestedActions
             chatId={chatId}
             selectedVisibilityType={selectedVisibilityType}
             sendMessage={sendMessage}
           />
-        )}
+        ))}
 
       <input
         className="-top-4 -left-4 pointer-events-none fixed size-0.5 opacity-0"
@@ -257,6 +275,11 @@ function PureMultimodalInput({
         className="rounded-xl border border-border bg-background p-3 shadow-xs transition-all duration-200 focus-within:border-border hover:border-muted-foreground/50"
         onSubmit={(event) => {
           event.preventDefault();
+          if (isOnboardingActive) {
+            onCompleteOnboarding();
+            return;
+          }
+
           if (status !== "ready") {
             toast.error("Please wait for the model to finish its response!");
           } else {
@@ -300,13 +323,19 @@ function PureMultimodalInput({
         <div className="flex flex-row items-start gap-1 sm:gap-2">
           <PromptInputTextarea
             autoFocus
+            aria-disabled={isOnboardingActive}
             className="grow resize-none border-0! border-none! bg-transparent p-2 text-sm outline-none ring-0 [-ms-overflow-style:none] [scrollbar-width:none] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-scrollbar]:hidden"
             data-testid="multimodal-input"
             disableAutoResize={true}
             maxHeight={200}
             minHeight={44}
             onChange={handleInput}
-            placeholder="Send a message..."
+            placeholder={
+              isOnboardingActive
+                ? "온보딩을 마치고 대화를 시작해 보세요"
+                : "Send a message..."
+            }
+            readOnly={isOnboardingActive}
             ref={textareaRef}
             rows={1}
             value={input}
@@ -317,6 +346,7 @@ function PureMultimodalInput({
           <PromptInputTools className="gap-0 sm:gap-0.5">
             <AttachmentsButton
               fileInputRef={fileInputRef}
+              isDisabled={isOnboardingActive}
               selectedModelId={selectedModelId}
               status={status}
             />
@@ -331,7 +361,9 @@ function PureMultimodalInput({
           ) : (
             <PromptInputSubmit
               className="size-8 rounded-full bg-primary text-primary-foreground transition-colors duration-200 hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground"
-              disabled={!input.trim() || uploadQueue.length > 0}
+              disabled={
+                isOnboardingActive || !input.trim() || uploadQueue.length > 0
+              }
               status={status}
             >
               <ArrowUpIcon size={14} />
@@ -361,19 +393,58 @@ export const MultimodalInput = memo(
     if (prevProps.selectedModelId !== nextProps.selectedModelId) {
       return false;
     }
+    if (prevProps.isOnboardingActive !== nextProps.isOnboardingActive) {
+      return false;
+    }
+    if (
+      prevProps.isCompletingOnboarding !== nextProps.isCompletingOnboarding
+    ) {
+      return false;
+    }
 
     return true;
   }
 );
 
+function OnboardingQuickStart({
+  onComplete,
+  isCompleting,
+}: {
+  onComplete: () => void;
+  isCompleting: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-primary/40 bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2 font-medium text-sm text-primary">
+          <Sparkles className="h-4 w-4" />
+          온보딩을 마치고 시작해 보세요
+        </span>
+        <p className="text-sm text-muted-foreground">
+          주요 기능을 확인했다면 지금 바로 첫 질문을 남겨 보세요.
+        </p>
+      </div>
+      <Button
+        className="w-full sm:w-auto"
+        disabled={isCompleting}
+        onClick={onComplete}
+      >
+        {isCompleting ? "저장 중..." : "온보딩 완료하기"}
+      </Button>
+    </div>
+  );
+}
+
 function PureAttachmentsButton({
   fileInputRef,
   status,
   selectedModelId,
+  isDisabled,
 }: {
   fileInputRef: React.MutableRefObject<HTMLInputElement | null>;
   status: UseChatHelpers<ChatMessage>["status"];
   selectedModelId: string;
+  isDisabled: boolean;
 }) {
   const isReasoningModel = selectedModelId === "chat-model-reasoning";
 
@@ -381,7 +452,7 @@ function PureAttachmentsButton({
     <Button
       className="aspect-square h-8 rounded-lg p-1 transition-colors hover:bg-accent"
       data-testid="attachments-button"
-      disabled={status !== "ready" || isReasoningModel}
+      disabled={status !== "ready" || isReasoningModel || isDisabled}
       onClick={(event) => {
         event.preventDefault();
         fileInputRef.current?.click();

--- a/packages/ai_frontend/components/onboarding.tsx
+++ b/packages/ai_frontend/components/onboarding.tsx
@@ -1,0 +1,88 @@
+import { CheckCircle2, Sparkles } from "lucide-react";
+import { Button } from "./ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+
+type OnboardingProps = {
+  onComplete: () => void;
+  isCompleting?: boolean;
+  onSkip?: () => void;
+};
+
+const checklist = [
+  {
+    title: "법령과 판례를 한번에 검색",
+    description:
+      "관련 법령, 해설, 판례를 통합 검색해 답변과 함께 근거를 제공합니다.",
+  },
+  {
+    title: "문서 초안 작성 지원",
+    description:
+      "계약서나 의견서 초안을 생성하고 필요한 근거 조항을 자동으로 인용합니다.",
+  },
+  {
+    title: "대화 맥락 유지",
+    description:
+      "이전 질문 흐름을 유지하며 추가 질문이나 자료 업로드에도 대응합니다.",
+  },
+];
+
+export function Onboarding({ onComplete, isCompleting, onSkip }: OnboardingProps) {
+  return (
+    <Card className="mx-auto mt-6 w-full max-w-3xl border-primary/30 bg-background/80 backdrop-blur">
+      <CardHeader className="gap-3">
+        <div className="flex items-center gap-2 text-primary">
+          <Sparkles className="h-5 w-5" />
+          <span className="font-semibold text-sm uppercase tracking-wide">
+            온보딩
+          </span>
+        </div>
+        <CardTitle className="text-2xl">AI 법률 도우미와 함께 시작하세요</CardTitle>
+        <CardDescription className="text-base">
+          아래 기능을 훑어보고 준비가 되면 대화를 시작하세요. 언제든지 좌측
+          메뉴에서 새로운 상담을 열 수 있습니다.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {checklist.map((item) => (
+          <div className="flex items-start gap-3" key={item.title}>
+            <CheckCircle2 className="mt-1 h-5 w-5 text-primary" />
+            <div className="space-y-1">
+              <p className="font-medium text-sm md:text-base">{item.title}</p>
+              <p className="text-sm text-muted-foreground">{item.description}</p>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+      <CardFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-muted-foreground">
+          대화를 시작하면 온보딩은 자동으로 완료 처리됩니다.
+        </p>
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+          {onSkip && (
+            <Button
+              className="w-full sm:w-auto"
+              onClick={onSkip}
+              variant="ghost"
+            >
+              나중에 보기
+            </Button>
+          )}
+          <Button
+            className="w-full sm:w-auto"
+            disabled={isCompleting}
+            onClick={onComplete}
+          >
+            {isCompleting ? "시작 준비 중..." : "지금 시작하기"}
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/packages/ai_frontend/components/suggested-actions.tsx
+++ b/packages/ai_frontend/components/suggested-actions.tsx
@@ -15,10 +15,10 @@ type SuggestedActionsProps = {
 
 function PureSuggestedActions({ chatId, sendMessage }: SuggestedActionsProps) {
   const suggestedActions = [
-    "What are the advantages of using Next.js?",
-    "Write code to demonstrate Dijkstra's algorithm",
-    "Help me write an essay about Silicon Valley",
-    "What is the weather in San Francisco?",
+    "최근 개정된 근로기준법의 핵심 변화를 정리해줘",
+    "가맹계약 해지 통보서에 반드시 들어가야 할 조항은?",
+    "개인정보 유출 사고 대응 매뉴얼 초안을 작성해줘",
+    "부동산 임대차 계약 분쟁에서 참고할 판례를 찾아줘",
   ];
 
   return (


### PR DESCRIPTION
## Summary
- persist onboarding completion with a dedicated cookie and server action
- surface a chat onboarding experience with new components and wiring throughout the chat shell
- tailor initial suggested prompts to legal workflows and gate the input until onboarding completes

## Testing
- pnpm lint *(fails: existing lint violations in unrelated auth pages and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68db3f11785483218208fb15e97de6ed

## Summary by Sourcery

Implement a guided chat onboarding experience that persists completion state in cookies, disables core chat interactions until finished, and presents legal-focused suggested prompts

New Features:
- Introduce a chat onboarding flow with new Onboarding and OnboardingQuickStart components
- Persist onboarding completion via a cookie and a server action

Enhancements:
- Gate the chat input, attachments, and submit button until onboarding is completed
- Update initial suggested prompts to focus on legal workflows