### PR TITLE
fix(frontend): detect secure cookies per request

### DIFF
--- a/packages/ai_frontend/middleware.ts
+++ b/packages/ai_frontend/middleware.ts
@@ -1,7 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
 import { getAuthSecret } from "./lib/auth";
-import { isDevelopmentEnvironment } from "./lib/constants";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -18,10 +17,17 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  const forwardedProto = request.headers
+    .get("x-forwarded-proto")
+    ?.split(",")[0]
+    .trim();
+  const isSecure =
+    request.nextUrl.protocol === "https:" || forwardedProto === "https";
+
   const token = await getToken({
     req: request,
     secret: getAuthSecret(),
-    secureCookie: !isDevelopmentEnvironment,
+    secureCookie: isSecure,
   });
 
   const authRoutes = ["/login", "/register"];


### PR DESCRIPTION
## Summary
- derive the secure cookie flag from the incoming request protocol before reading the session token
- prevent the auth middleware from missing cookies on HTTP deployments and redirecting back to login

## Testing
- pnpm --dir packages/ai_frontend lint *(fails: existing lint complaints in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db5f72b5ec8321879d8e12199fef55

## Summary by Sourcery

Bug Fixes:
- Detect secure cookies per request using request.nextUrl.protocol and the x-forwarded-proto header instead of a static environment flag to prevent missing cookies and erroneous login redirects.