### PR TITLE
fix: handle failed credential redirects

### DIFF
--- a/packages/ai_frontend/app/(auth)/login/page.tsx
+++ b/packages/ai_frontend/app/(auth)/login/page.tsx
@@ -31,6 +31,15 @@ function LoginPageContent() {
   const { update: updateSession } = useSession();
 
   useEffect(() => {
+    if (state.status === "success") {
+      setIsSuccessful(true);
+      updateSession();
+      router.push(nextPath);
+      return;
+    }
+
+    setIsSuccessful(false);
+
     if (state.status === "failed") {
       toast({
         type: "error",
@@ -41,10 +50,6 @@ function LoginPageContent() {
         type: "error",
         description: "Failed validating your submission!",
       });
-    } else if (state.status === "success") {
-      setIsSuccessful(true);
-      updateSession();
-      router.push(nextPath);
     }
   }, [state.status, nextPath, router, updateSession]);
 

--- a/packages/ai_frontend/tests/e2e/session.test.ts
+++ b/packages/ai_frontend/tests/e2e/session.test.ts
@@ -37,4 +37,16 @@ test.describe.serial("Authentication gating", () => {
     await authPage.login(user.email, user.password);
     await chatPage.expectHomeLoaded();
   });
+
+  test("shows an error toast and re-enables the button on invalid login", async ({ page }) => {
+    const authPage = new AuthPage(page);
+
+    await authPage.login("nobody@example.com", "wrong-password");
+
+    await authPage.expectToastToContain("Invalid credentials!");
+
+    const submitButton = page.getByRole("button", { name: /sign in/i });
+    await expect(submitButton).toBeEnabled();
+    await expect(page).toHaveURL(/\/login/);
+  });
 });


### PR DESCRIPTION
## Summary
- detect failed NextAuth responses when signing in or registering and surface a failed status back to the client
- reset the login button state unless a real success is reported before navigating away
- cover invalid credential attempts with a Playwright test that checks the toast and button state

## Testing
- not run (Playwright e2e suite requires the Next.js dev server which is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbe5dca22883218a7dcee2252994c6

## Summary by Sourcery

Handle failed credential redirects by detecting NextAuth sign in errors in login and registration actions, surface failure status to the client, reset UI state on failure, and verify the behavior with a new e2e test.

Bug Fixes:
- Detect and return a failed status for NextAuth credential sign in failures in both login and registration flows
- Prevent unintended navigation on failed sign in attempts

Enhancements:
- Reset login button state on authentication failure and only navigate on successful sign in

Tests:
- Add Playwright end-to-end test for invalid login to verify error toast, button re-enable, and URL retention