### PR TITLE
fix(chat): handle provider authentication failures

### DIFF
--- a/packages/ai_frontend/app/(chat)/api/chat/route.ts
+++ b/packages/ai_frontend/app/(chat)/api/chat/route.ts
@@ -326,7 +326,7 @@ export async function POST(request: Request) {
       return error.toResponse();
     }
 
-    if (APICallError.isInstance(error)) {
+    if (error instanceof APICallError) {
       const { statusCode, responseBody, message } = error;
       const responseText =
         typeof responseBody === "string" && responseBody.length > 0

--- a/packages/ai_frontend/app/(chat)/api/chat/route.ts
+++ b/packages/ai_frontend/app/(chat)/api/chat/route.ts
@@ -1,5 +1,6 @@
 import { geolocation } from "@vercel/functions";
 import {
+  APICallError,
   convertToModelMessages,
   createUIMessageStream,
   JsonToSseTransformStream,
@@ -323,6 +324,27 @@ export async function POST(request: Request) {
 
     if (error instanceof ChatSDKError) {
       return error.toResponse();
+    }
+
+    if (APICallError.isInstance(error)) {
+      const { statusCode, responseBody, message } = error;
+      const responseText =
+        typeof responseBody === "string" && responseBody.length > 0
+          ? responseBody
+          : undefined;
+      const cause = responseText ?? message;
+
+      if (statusCode === 429) {
+        return new ChatSDKError("rate_limit:provider", cause).toResponse();
+      }
+
+      if (
+        statusCode === 401 ||
+        statusCode === 403 ||
+        (statusCode === 400 && responseText?.includes("API key not valid"))
+      ) {
+        return new ChatSDKError("unauthorized:provider", cause).toResponse();
+      }
     }
 
     // Check for Vercel AI Gateway credit card error

--- a/packages/ai_frontend/lib/errors.ts
+++ b/packages/ai_frontend/lib/errors.ts
@@ -16,7 +16,8 @@ export type Surface =
   | "vote"
   | "document"
   | "suggestions"
-  | "activate_gateway";
+  | "activate_gateway"
+  | "provider";
 
 export type ErrorCode = `${ErrorType}:${Surface}`;
 
@@ -33,6 +34,7 @@ export const visibilityBySurface: Record<Surface, ErrorVisibility> = {
   document: "response",
   suggestions: "response",
   activate_gateway: "response",
+  provider: "response",
 };
 
 export class ChatSDKError extends Error {
@@ -102,6 +104,11 @@ export function getMessageByErrorCode(errorCode: ErrorCode): string {
       return "You need to sign in to view this chat. Please sign in and try again.";
     case "offline:chat":
       return "We're having trouble sending your message. Please check your internet connection and try again.";
+
+    case "unauthorized:provider":
+      return "The configured AI provider rejected the request. Check your API key and base URL settings.";
+    case "rate_limit:provider":
+      return "The AI provider is rate limiting requests. Please wait a moment and try again.";
 
     case "not_found:document":
       return "The requested document was not found. Please check the document ID and try again.";


### PR DESCRIPTION
## Summary
- add provider-specific ChatSDK error handling and messaging
- map AI SDK API call failures to provider errors for invalid credentials and rate limits

## Testing
- pnpm --dir packages/ai_frontend lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df57de9e2483218df73eb5d7457d9f

## Summary by Sourcery

Handle AI provider authentication and rate limit errors by intercepting APICallError instances, mapping them to new ChatSDKError codes, and updating the error surface and messages accordingly

New Features:
- Map AI SDK API call failures to ChatSDKError codes 'rate_limit:provider' and 'unauthorized:provider' based on HTTP status and response content

Enhancements:
- Add 'provider' error surface with response visibility
- Define user-facing messages for unauthorized:provider and rate_limit:provider error codes