### PR TITLE
chore(ai-frontend): add cloudflare analytics beacon

### DIFF
--- a/packages/ai_frontend/app/layout.tsx
+++ b/packages/ai_frontend/app/layout.tsx
@@ -71,6 +71,11 @@ export default function RootLayout({
             __html: THEME_COLOR_SCRIPT,
           }}
         />
+        <script
+          defer
+          data-cf-beacon='{"token": "897aad97e10143c6a0bfbbd899b6a07e"}'
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+        />
       </head>
       <body className="antialiased">
         <ThemeProvider


### PR DESCRIPTION
## Summary
- add the Cloudflare Web Analytics beacon script to the ai_frontend layout head

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df609047448321bb5d2b52fdfd9c13

## Summary by Sourcery

Enhancements:
- Integrate Cloudflare Web Analytics by adding the beacon script tag to the layout head.