### PR TITLE
feat(ai_frontend): ensure chat agent finishes after tool cap

### DIFF
--- a/packages/ai_frontend/app/(chat)/api/chat/route.ts
+++ b/packages/ai_frontend/app/(chat)/api/chat/route.ts
@@ -73,11 +73,28 @@ export const MAX_TOOL_STEPS = (() => {
     return DEFAULT_MAX_TOOL_STEPS;
   }
 
+  // Strict validation: must be a positive integer string
+  if (!/^\d+$/.test(rawValue)) {
+    if (typeof console !== "undefined" && typeof console.warn === "function") {
+      console.warn(
+        `[MAX_TOOL_STEPS] Invalid environment variable value: "${rawValue}". Must be a positive integer. Using default (${DEFAULT_MAX_TOOL_STEPS}).`
+      );
+    }
+    return DEFAULT_MAX_TOOL_STEPS;
+  }
+
   const parsed = Number.parseInt(rawValue, 10);
 
-  return Number.isFinite(parsed) && parsed > 0
-    ? parsed
-    : DEFAULT_MAX_TOOL_STEPS;
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    if (typeof console !== "undefined" && typeof console.warn === "function") {
+      console.warn(
+        `[MAX_TOOL_STEPS] Environment variable value is not a positive integer: "${rawValue}". Using default (${DEFAULT_MAX_TOOL_STEPS}).`
+      );
+    }
+    return DEFAULT_MAX_TOOL_STEPS;
+  }
+
+  return parsed;
 })();
 
 function mergeUsage(


### PR DESCRIPTION
## Summary
- add a configurable MAX_TOOL_STEPS constant for the chat API and track aggregated usage across continuations
- make the chat stream executor async, consume the stream, and request a final assistant turn when the tool ceiling is hit
- clarify logging/comments to reflect the guaranteed concluding assistant response once the tool budget is exhausted

## Testing
- pnpm -C packages/ai_frontend lint *(fails: pre-existing lint violations across the frontend package)*

------
https://chatgpt.com/codex/tasks/task_e_68df8082df848321855f8c6fd6e0c835

## Summary by Sourcery

Introduce a tunable tool invocation limit for the chat agent and refactor the streaming executor to aggregate usage data and ensure the agent always issues a concluding assistant message when the tool step budget is exhausted

New Features:
- Add configurable MAX_TOOL_STEPS to cap tool invocations and request a final assistant turn when the limit is reached

Enhancements:
- Refactor chat stream executor to async, abstract stream creation, and aggregate/enrich usage telemetry across runs
- Detect unfinished tool runs and trigger a no-tool continuation to guarantee a final assistant response after the tool ceiling