### PR TITLE
feat(frontend): add MCP completion demo endpoint

### DIFF
--- a/packages/ai_frontend/.env.example
+++ b/packages/ai_frontend/.env.example
@@ -14,6 +14,11 @@ AUTH_SECRET=****
 
 # Optional overrides for the law MCP server used by legal research tools
 # LAW_MCP_BASE_URL=http://127.0.0.1:8000/mcp
+# LAW_MCP_TRANSPORT=streamable-http
+# LAW_MCP_STDIO_COMMAND=uv
+# LAW_MCP_STDIO_ARGS=run law-mcp-server
+# LAW_MCP_HTTP_URL=http://127.0.0.1:8000/mcp
+# LAW_MCP_SSE_URL=http://127.0.0.1:8000/sse
 
 
 # Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob

--- a/packages/ai_frontend/README.md
+++ b/packages/ai_frontend/README.md
@@ -85,6 +85,10 @@ uv run law-mcp-server  # defaults to http://127.0.0.1:8000/mcp
 
 Override the target endpoint with the `LAW_MCP_BASE_URL` environment variable if the server runs on another host/port.
 
+- Use `LAW_MCP_TRANSPORT` to select the transports that should be merged by the `/api/completion` route. Provide a comma-separated list such as `streamable-http,sse` or `stdio,streamable-http`. The default is `streamable-http`.
+- When launching the stdio transport locally, set `LAW_MCP_STDIO_COMMAND` and `LAW_MCP_STDIO_ARGS` if you need to customize the spawn command (defaults to `uv` and `run law-mcp-server`).
+- Override derived URLs for additional transports with `LAW_MCP_HTTP_URL` or `LAW_MCP_SSE_URL` when the MCP server exposes different endpoints.
+
 ```bash
 pnpm install
 pnpm dev
@@ -93,3 +97,5 @@ pnpm dev
 The dev server listens on [http://127.0.0.1:8080](http://127.0.0.1:8080) by default.
 
 > ⚠️ The chat UI now requires an authenticated session. After launching the dev server, visit [`/register`](http://localhost:3000/register) to create an account before opening the chat interface. Any API requests made without a session cookie will return a `401 Unauthorized` response or redirect you back to the login page.
+
+After signing in you can visit [`/mcp`](http://localhost:3000/mcp) to trigger the MCP-enabled completion demo without disturbing existing chat threads.

--- a/packages/ai_frontend/app/(chat)/api/completion/route.ts
+++ b/packages/ai_frontend/app/(chat)/api/completion/route.ts
@@ -1,0 +1,188 @@
+import { experimental_createMCPClient, streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
+
+export const runtime = "nodejs";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:8000/mcp";
+
+const TRANSPORT_ALIASES: Record<string, string> = {
+  http: "streamable-http",
+  "streamable-http": "streamable-http",
+  sse: "sse",
+  stdio: "stdio",
+};
+
+type McpClient = Awaited<ReturnType<typeof experimental_createMCPClient>>;
+type McpToolMap = Awaited<ReturnType<McpClient["tools"]>>;
+
+type CompletionRequestBody = {
+  prompt: string;
+};
+
+function parseTransportList(): string[] {
+  const configured = process.env.LAW_MCP_TRANSPORT ?? "streamable-http";
+  const values = configured
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .map((entry) => TRANSPORT_ALIASES[entry] ?? entry);
+
+  return Array.from(new Set(values));
+}
+
+function resolveBaseUrl(): URL {
+  const base = process.env.LAW_MCP_BASE_URL ?? DEFAULT_BASE_URL;
+  return new URL(base);
+}
+
+function resolveSseUrl(base: URL): URL {
+  const override = process.env.LAW_MCP_SSE_URL;
+  if (override) {
+    return new URL(override);
+  }
+
+  const derived = new URL(base.toString());
+  derived.pathname = derived.pathname.replace(/\/?$/, "/");
+  derived.pathname = `${derived.pathname.replace(/mcp\/?$/, "")}sse`;
+  return derived;
+}
+
+function parseArgs(rawArgs: string | undefined): string[] {
+  if (!rawArgs) {
+    return ["run", "law-mcp-server"];
+  }
+
+  return rawArgs
+    .trim()
+    .split(/\s+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export async function POST(request: Request) {
+  let prompt: string;
+
+  try {
+    const body = (await request.json()) as CompletionRequestBody;
+    if (typeof body.prompt !== "string") {
+      return new Response("Missing prompt", { status: 400 });
+    }
+    prompt = body.prompt.trim();
+  } catch {
+    return new Response("Invalid request body", { status: 400 });
+  }
+
+  if (!prompt) {
+    return new Response("Missing prompt", { status: 400 });
+  }
+
+  const transports = parseTransportList();
+
+  const clients: McpClient[] = [];
+  let closed = false;
+
+  const closeAllClients = async () => {
+    if (closed) {
+      return;
+    }
+
+    closed = true;
+
+    await Promise.allSettled(
+      clients.map((client) => client.close().catch(() => undefined))
+    );
+  };
+
+  try {
+    const baseUrl = resolveBaseUrl();
+    const tools: McpToolMap = {};
+
+    if (transports.includes("stdio")) {
+      const command = process.env.LAW_MCP_STDIO_COMMAND ?? "uv";
+      const args = parseArgs(process.env.LAW_MCP_STDIO_ARGS);
+
+      const stdioTransport = new StdioClientTransport({
+        command,
+        args,
+        env: {
+          ...process.env,
+          LAW_MCP_TRANSPORT: "stdio",
+        },
+      });
+
+      const stdioClient = await experimental_createMCPClient({
+        transport: stdioTransport,
+      });
+
+      clients.push(stdioClient);
+
+      const toolset = await stdioClient.tools();
+      for (const [name, tool] of Object.entries(toolset)) {
+        if (!(name in tools)) {
+          tools[name] = tool;
+        }
+      }
+    }
+
+    if (transports.includes("streamable-http")) {
+      const httpUrl = process.env.LAW_MCP_HTTP_URL
+        ? new URL(process.env.LAW_MCP_HTTP_URL)
+        : baseUrl;
+
+      const httpClient = await experimental_createMCPClient({
+        transport: new StreamableHTTPClientTransport(httpUrl),
+      });
+
+      clients.push(httpClient);
+
+      const toolset = await httpClient.tools();
+      for (const [name, tool] of Object.entries(toolset)) {
+        if (!(name in tools)) {
+          tools[name] = tool;
+        }
+      }
+    }
+
+    if (transports.includes("sse")) {
+      const sseUrl = resolveSseUrl(baseUrl);
+      const sseClient = await experimental_createMCPClient({
+        transport: new SSEClientTransport(sseUrl),
+      });
+
+      clients.push(sseClient);
+
+      const toolset = await sseClient.tools();
+      for (const [name, tool] of Object.entries(toolset)) {
+        if (!(name in tools)) {
+          tools[name] = tool;
+        }
+      }
+    }
+
+    if (clients.length === 0) {
+      await closeAllClients();
+      return new Response("No MCP transports configured", { status: 503 });
+    }
+
+    const response = await streamText({
+      model: openai("gpt-4o"),
+      prompt,
+      tools,
+      onFinish: async () => {
+        await closeAllClients();
+      },
+      onError: async () => {
+        await closeAllClients();
+      },
+    });
+
+    return response.toDataStreamResponse();
+  } catch (error) {
+    await closeAllClients();
+    console.error("/api/completion failed", error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/packages/ai_frontend/app/(chat)/mcp/mcp-demo.tsx
+++ b/packages/ai_frontend/app/(chat)/mcp/mcp-demo.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCompletion } from "@ai-sdk/react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+
+const DEFAULT_PROMPT =
+  "Please schedule a call with Sonny and Robby for tomorrow at 10am ET for me!";
+
+export function McpDemo() {
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const { completion, complete, isLoading, error } = useCompletion({
+    api: "/api/completion",
+  });
+
+  const errorMessage =
+    typeof error === "string" ? error : error?.message ?? undefined;
+
+  const handleSubmit = async () => {
+    await complete(prompt);
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Model Context Protocol demo</CardTitle>
+          <CardDescription>
+            Trigger the dedicated completion endpoint that merges MCP tools from
+            stdio, Streamable HTTP, and SSE transports.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Textarea
+            aria-label="MCP prompt"
+            disabled={isLoading}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="Enter a prompt to send to the MCP-enabled completion endpoint"
+            value={prompt}
+          />
+          <div className="flex flex-row gap-2">
+            <Button
+              disabled={isLoading || !prompt.trim()}
+              onClick={handleSubmit}
+              type="button"
+            >
+              {isLoading ? "Running..." : "Run completion"}
+            </Button>
+            <Button
+              disabled={isLoading}
+              onClick={() => setPrompt(DEFAULT_PROMPT)}
+              type="button"
+              variant="outline"
+            >
+              Reset prompt
+            </Button>
+          </div>
+          {errorMessage && (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          )}
+          {completion && (
+            <div className="rounded-md border bg-muted/30 p-4 text-sm whitespace-pre-wrap">
+              {completion}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/ai_frontend/app/(chat)/mcp/page.tsx
+++ b/packages/ai_frontend/app/(chat)/mcp/page.tsx
@@ -1,0 +1,24 @@
+import { redirect } from "next/navigation";
+import { McpDemo } from "./mcp-demo";
+import { auth } from "../../(auth)/auth";
+
+export default async function McpPage() {
+  const session = await auth();
+
+  if (!session) {
+    redirect(`/login?redirectUrl=${encodeURIComponent("/mcp")}`);
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-4 md:p-8">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold tracking-tight">MCP completion demo</h1>
+        <p className="text-muted-foreground text-sm">
+          Explore the standalone completion endpoint that merges tool catalogs
+          from configured Model Context Protocol transports.
+        </p>
+      </div>
+      <McpDemo />
+    </div>
+  );
+}

--- a/packages/ai_frontend/components/app-sidebar.tsx
+++ b/packages/ai_frontend/components/app-sidebar.tsx
@@ -13,6 +13,8 @@ import {
   SidebarFooter,
   SidebarHeader,
   SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -60,6 +62,21 @@ export function AppSidebar({ user }: { user: User | undefined }) {
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild>
+              <Link
+                className="truncate"
+                href="/mcp"
+                onClick={() => {
+                  setOpenMobile(false);
+                }}
+              >
+                MCP completion demo
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
         <SidebarHistory user={user} />
       </SidebarContent>
       <SidebarFooter>{user && <SidebarUserNav user={user} />}</SidebarFooter>

--- a/packages/ai_frontend/package.json
+++ b/packages/ai_frontend/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^1.0.19",
+    "@ai-sdk/openai": "1.0.20",
     "@ai-sdk/provider": "2.0.0",
     "@ai-sdk/react": "2.0.26",
     "@codemirror/lang-javascript": "^6.2.2",
@@ -39,6 +40,7 @@
     "@vercel/otel": "^1.12.0",
     "@vercel/postgres": "^0.10.0",
     "ai": "5.0.26",
+    "@modelcontextprotocol/sdk": "0.6.1",
     "bcrypt-ts": "^5.0.2",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",

--- a/packages/ai_frontend/pnpm-lock.yaml
+++ b/packages/ai_frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: 1.0.20
+        version: 1.0.20(zod@3.25.76)
       '@ai-sdk/openai-compatible':
         specifier: ^1.0.19
         version: 1.0.19(zod@3.25.76)
@@ -35,6 +38,9 @@ importers:
       '@icons-pack/react-simple-icons':
         specifier: ^13.7.0
         version: 13.7.0(react@19.0.0-rc-45804af1-20241021)
+      '@modelcontextprotocol/sdk':
+        specifier: 0.6.1
+        version: 0.6.1
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -282,6 +288,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@1.0.20':
+    resolution: {integrity: sha512-824Eyqn83GxjUiErX9J0S8ffSVw1JKh8iYJNVSFxPvOVzA02KNEIakOhcQHWxb65aTOYxytD+6YR7m/ppHY6IQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/provider-utils@2.0.8':
+    resolution: {integrity: sha512-R/wsIqx7Lwhq+ogzkqSOek8foj2wOnyBSGW/CH8IPBla0agbisIE9Ug7R9HDTNiBbIIKVhduB54qQSMPFw0MZA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@ai-sdk/provider-utils@3.0.10':
     resolution: {integrity: sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==}
     engines: {node: '>=18'}
@@ -293,6 +314,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider@1.0.4':
+    resolution: {integrity: sha512-lJi5zwDosvvZER3e/pB8lj1MN3o3S7zJliQq56BRr4e9V3fcRyFtwP0JRxaRS5vHYX3OJ154VezVoQNrk0eaKw==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
@@ -1052,6 +1077,9 @@ packages:
 
   '@mermaid-js/parser@0.6.2':
     resolution: {integrity: sha512-+PO02uGF6L6Cs0Bw8RpGhikVvMWEysfAyl27qTlroUB8jSWr1lL0Sf6zi78ZxlSnmgSY2AMMKVgghnN9jTtwkQ==}
+
+  '@modelcontextprotocol/sdk@0.6.1':
+    resolution: {integrity: sha512-OkVXMix3EIbB5Z6yife2XTrSlOnVvCLR1Kg91I4pYFEsV9RbnoyQVScXCuVhGaZHOnTZgso8lMQN1Po2TadGKQ==}
 
   '@neondatabase/serverless@0.9.5':
     resolution: {integrity: sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==}
@@ -2597,6 +2625,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
@@ -2811,6 +2843,10 @@ packages:
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3133,9 +3169,20 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.0:
+    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
@@ -3796,6 +3843,10 @@ packages:
       '@types/react-dom':
         optional: true
 
+  raw-body@3.0.1:
+    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
+    engines: {node: '>= 0.10'}
+
   react-data-grid@7.0.0-beta.47:
     resolution: {integrity: sha512-28kjsmwQGD/9RXYC50zn5Zv/SQMhBBoSvG5seq0fM8XXi9TZ0zr9Z5T3YJqLwcEtoNzTOq3y0njkmdujGkIwQQ==}
     peerDependencies:
@@ -3928,6 +3979,9 @@ packages:
   scheduler@0.25.0-rc-45804af1-20241021:
     resolution: {integrity: sha512-8jyu/iy3tGFNakMMCWnKw/vsiTcapDyl0LKlZ3fUKBcBicZAkrrCC1bdqVFx0Ioxgry1SzOrCGcZLM7vtWK00A==}
 
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
@@ -3935,6 +3989,9 @@ packages:
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -3977,6 +4034,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
@@ -4077,6 +4138,10 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tokenlens@1.3.0:
     resolution: {integrity: sha512-qrwHFO7CI8HEd+UvKjlL+veTzCVr3N4AYp3cquGL6z62Q/OtoEHbTv5uNqiiejP54y7eR+h8VVRRpZbm3t/99Q==}
 
@@ -4156,6 +4221,10 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -4366,6 +4435,21 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.10(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/openai@1.0.20(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.0.4
+      '@ai-sdk/provider-utils': 2.0.8(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@2.0.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.0.4
+      eventsource-parser: 3.0.5
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+    optionalDependencies:
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@3.0.10(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -4379,6 +4463,10 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.5
       zod: 3.25.76
+
+  '@ai-sdk/provider@1.0.4':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@2.0.0':
     dependencies:
@@ -4940,6 +5028,12 @@ snapshots:
   '@mermaid-js/parser@0.6.2':
     dependencies:
       langium: 3.3.1
+
+  '@modelcontextprotocol/sdk@0.6.1':
+    dependencies:
+      content-type: 1.0.5
+      raw-body: 3.0.1
+      zod: 3.25.76
 
   '@neondatabase/serverless@0.9.5':
     dependencies:
@@ -6441,6 +6535,8 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-type@1.0.5: {}
+
   cookie@0.7.1: {}
 
   cose-base@1.0.3:
@@ -6664,6 +6760,8 @@ snapshots:
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -7016,9 +7114,23 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  iconv-lite@0.7.0:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
 
   inline-style-parser@0.2.4: {}
 
@@ -7968,6 +8080,13 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  raw-body@3.0.1:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.7.0
+      unpipe: 1.0.0
+
   react-data-grid@7.0.0-beta.47(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021):
     dependencies:
       clsx: 2.1.1
@@ -8175,10 +8294,14 @@ snapshots:
 
   scheduler@0.25.0-rc-45804af1-20241021: {}
 
+  secure-json-parse@2.7.0: {}
+
   semver@7.7.1:
     optional: true
 
   server-only@0.0.1: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.33.5:
     dependencies:
@@ -8246,6 +8369,8 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.1: {}
 
   std-env@3.9.0: {}
 
@@ -8342,6 +8467,8 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
+
+  toidentifier@1.0.1: {}
 
   tokenlens@1.3.0:
     dependencies:
@@ -8463,6 +8590,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+
+  unpipe@1.0.0: {}
 
   use-callback-ref@1.3.3(@types/react@18.3.18)(react@19.0.0-rc-45804af1-20241021):
     dependencies:


### PR DESCRIPTION
## Summary
- add a dedicated /api/completion route that merges tools from stdio, streamable HTTP, and SSE MCP transports with configurable environment overrides
- surface a gated MCP completion demo page and sidebar link so authenticated users can call the new endpoint from the UI
- document the new transport variables and dependencies needed to run the MCP demo locally

## Testing
- not run (requires project-specific Postgres/Redis configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e0cf2eaa788321b224c48a44b05879