### PR TITLE
refactor(ai): use mcp sdk client in law tools

### DIFF
--- a/packages/ai_frontend/lib/ai/tools/law-mcp-client.ts
+++ b/packages/ai_frontend/lib/ai/tools/law-mcp-client.ts
@@ -1,239 +1,67 @@
-import { randomUUID } from "crypto";
+import { experimental_createMCPClient } from "ai";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 const DEFAULT_BASE_URL =
   process.env.LAW_MCP_BASE_URL ?? "http://127.0.0.1:8000/mcp";
 
-const PROTOCOL_VERSION = "2024-11-05";
 const CLIENT_NAME = "ai-frontend";
-const CLIENT_VERSION = process.env.VERCEL_GIT_COMMIT_SHA ?? "0.0.0";
 
-type JsonRpcBase = {
-  jsonrpc: "2.0";
+type McpClient = Awaited<ReturnType<typeof experimental_createMCPClient>>;
+type McpToolMap = Awaited<ReturnType<McpClient["tools"]>>;
+type McpTool = McpToolMap[string];
+type McpToolExecuteResult = Awaited<ReturnType<McpTool["execute"]>>;
+
+type ExtractedContent = {
+  type?: string;
+  text?: string;
 };
 
-type JsonRpcRequest = JsonRpcBase & {
-  id?: string;
-  method: string;
-  params?: Record<string, unknown>;
-};
+function createTransport(baseUrl: string) {
+  try {
+    return new StreamableHTTPClientTransport(new URL(baseUrl));
+  } catch (error) {
+    throw new Error(`Invalid LAW_MCP_BASE_URL: ${baseUrl}`, { cause: error });
+  }
+}
 
-type JsonRpcResponse = JsonRpcBase &
-  (
-    | {
-        id: string | number | null;
-        result: unknown;
-      }
-    | {
-        id: string | number | null;
-        error: {
-          code: number;
-          message: string;
-          data?: unknown;
-        };
-      }
-  );
+function extractTextContent(result: McpToolExecuteResult): string | undefined {
+  if (!result || typeof result !== "object" || !("content" in result)) {
+    return undefined;
+  }
 
-type StreamableHttpResult =
-  | {
-      content?: Array<{ type: string; text?: string }>;
-      structuredContent?: { result?: unknown };
-      isError?: boolean;
-    }
-  | undefined;
+  const { content } = result as { content?: ExtractedContent[] };
 
-type McpMessage = {
-  id?: string | number | null;
-  result?: StreamableHttpResult;
-  error?: {
-    code: number;
-    message: string;
-    data?: unknown;
-  };
-};
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
 
-type SendOptions = {
-  sessionId?: string | null;
-  signal?: AbortSignal;
-};
-
-type SendResult = {
-  sessionId?: string | null;
-  message?: McpMessage;
-};
-
-type HandshakeState = {
-  sessionId: string | null;
-  initialized: boolean;
-  handshakePromise: Promise<void> | null;
-};
-
-const state: HandshakeState = {
-  sessionId: null,
-  initialized: false,
-  handshakePromise: null,
-};
-
-function parseSseStream(raw: string): McpMessage | undefined {
-  const blocks = raw
-    .split(/\n\n+/)
-    .map((block) => block.trim())
-    .filter(Boolean);
-
-  for (const block of blocks) {
-    const lines = block.split(/\n/);
-    let dataLines: string[] = [];
-    for (const line of lines) {
-      if (line.startsWith("data:")) {
-        const value = line.slice("data:".length).trimStart();
-        dataLines.push(value);
-      }
-    }
-
-    if (dataLines.length === 0) {
-      continue;
-    }
-
-    const data = dataLines.join("\n");
-
-    try {
-      const parsed = JSON.parse(data) as JsonRpcResponse;
-      if ("result" in parsed || "error" in parsed) {
-        return {
-          id: parsed.id,
-          result: (parsed as any).result,
-          error: (parsed as any).error,
-        };
-      }
-    } catch (error) {
-      console.warn("Failed to parse MCP SSE payload", { data, error });
+  for (const part of content) {
+    if (part && part.type === "text" && typeof part.text === "string") {
+      return part.text;
     }
   }
 
   return undefined;
 }
 
-async function sendRequest(
-  payload: JsonRpcRequest,
-  { sessionId, signal }: SendOptions
-): Promise<SendResult> {
-  const response = await fetch(DEFAULT_BASE_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      ...(sessionId ? { "mcp-session-id": sessionId } : {}),
-    },
-    body: JSON.stringify(payload),
-    signal,
-  });
+function extractResultPayload(result: McpToolExecuteResult): unknown {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
 
-  const responseText = await response.text();
-  const nextSessionId =
-    response.headers.get("mcp-session-id") ?? sessionId ?? undefined;
+  if ("toolResult" in result) {
+    return (result as { toolResult: unknown }).toolResult;
+  }
 
-  if (!response.ok) {
+  if ("isError" in result && (result as { isError?: boolean }).isError) {
     const errorMessage =
-      parseSseStream(responseText)?.error?.message ?? responseText;
-    throw new Error(
-      `MCP request failed with status ${response.status}: ${errorMessage}`
-    );
+      extractTextContent(result) ?? "Unknown MCP tool error";
+    throw new Error(errorMessage);
   }
 
-  return {
-    sessionId: nextSessionId ?? null,
-    message: parseSseStream(responseText),
-  };
-}
+  const textPayload = extractTextContent(result);
 
-async function performHandshake(signal?: AbortSignal) {
-  const payload: JsonRpcRequest = {
-    jsonrpc: "2.0",
-    id: randomUUID(),
-    method: "initialize",
-    params: {
-      protocolVersion: PROTOCOL_VERSION,
-      clientInfo: {
-        name: CLIENT_NAME,
-        version: CLIENT_VERSION,
-      },
-      capabilities: {},
-    },
-  };
-
-  const { sessionId, message } = await sendRequest(payload, {
-    signal,
-  });
-
-  if (!sessionId) {
-    throw new Error("Law MCP server did not provide a session id");
-  }
-
-  state.sessionId = sessionId;
-
-  if (message?.error) {
-    throw new Error(
-      `Failed to initialize MCP session: ${message.error.message}`
-    );
-  }
-
-  await sendRequest(
-    {
-      jsonrpc: "2.0",
-      method: "notifications/initialized",
-    },
-    { sessionId, signal }
-  );
-
-  state.initialized = true;
-}
-
-async function ensureSession(signal?: AbortSignal) {
-  if (state.initialized && state.sessionId) {
-    return;
-  }
-
-  if (!state.handshakePromise) {
-    state.handshakePromise = performHandshake(signal).catch((error) => {
-      state.sessionId = null;
-      state.initialized = false;
-      throw error;
-    });
-  }
-
-  try {
-    await state.handshakePromise;
-  } finally {
-    state.handshakePromise = null;
-  }
-}
-
-function extractResult(message?: McpMessage): unknown {
-  if (!message) {
-    return undefined;
-  }
-
-  if (message.error) {
-    throw new Error(message.error.message);
-  }
-
-  const result = message.result;
-
-  if (!result) {
-    return undefined;
-  }
-
-  if (result.isError) {
-    const errorText = result.content?.[0]?.text ?? "Unknown MCP tool error";
-    throw new Error(errorText);
-  }
-
-  if (result.structuredContent && "result" in result.structuredContent) {
-    return result.structuredContent.result;
-  }
-
-  const textPayload = result.content?.[0]?.text;
-
-  if (textPayload) {
+  if (typeof textPayload === "string") {
     try {
       return JSON.parse(textPayload);
     } catch (error) {
@@ -253,28 +81,30 @@ export async function callLawMcpTool<TResult>(
   args: Record<string, unknown>,
   { signal }: { signal?: AbortSignal } = {}
 ): Promise<TResult> {
-  await ensureSession(signal);
-
-  if (!state.sessionId) {
-    throw new Error("Law MCP session is not available");
-  }
-
-  const request: JsonRpcRequest = {
-    jsonrpc: "2.0",
-    id: randomUUID(),
-    method: "tools/call",
-    params: {
-      name: toolName,
-      arguments: args,
-    },
-  };
-
-  const { message } = await sendRequest(request, {
-    sessionId: state.sessionId,
-    signal,
+  const client = await experimental_createMCPClient({
+    name: CLIENT_NAME,
+    transport: createTransport(DEFAULT_BASE_URL),
   });
 
-  return extractResult(message) as TResult;
+  try {
+    const tools = await client.tools();
+    const tool = tools[toolName];
+
+    if (!tool) {
+      throw new Error(`MCP tool '${toolName}' is not available on the server`);
+    }
+
+    const executeOptions =
+      (signal !== undefined
+        ? ({ abortSignal: signal } as unknown)
+        : (undefined as unknown)) as Parameters<McpTool["execute"]>[1];
+
+    const result = await tool.execute(args, executeOptions);
+
+    return extractResultPayload(result) as TResult;
+  } finally {
+    await client.close();
+  }
 }
 
 export type LawMcpHit = {


### PR DESCRIPTION
## Summary
- replace the bespoke JSON-RPC session manager with the official MCP client helper in `callLawMcpTool`
- reuse the SDK tool metadata for result parsing while ensuring each client closes after invocation

## Testing
- pnpm lint *(fails: existing Biome lint diagnostics in unrelated files)*
- pnpm build *(fails: Next.js build requires POSTGRES_URL env var in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4786b09748321a2641162e2b7ff9b

## Summary by Sourcery

Refactor the law MCP tool integration to use the official MCP SDK client instead of a bespoke JSON-RPC implementation

Enhancements:
- Replace custom JSON-RPC session manager and SSE parsing with experimental_createMCPClient and StreamableHTTPClientTransport
- Leverage SDK tool metadata for invoking tools and parsing results
- Ensure each MCP client is properly closed after each tool invocation
- Add error handling for missing tools and invalid base URL